### PR TITLE
Changed "Search with Cliqz a" popup action behavior.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1496,7 +1496,7 @@ extension BrowserViewController: TabDelegate {
     }
 
     func tab(_ tab: Tab, didSelectSearchWithFirefoxForSelection selection: String) {
-        openSearchNewTab(isPrivate: tab.isPrivate, selection)
+        self.openBlankNewTab(focusLocationField: true, isPrivate: tab.isPrivate, searchFor: selection)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Ticket
fix #191 

## Description
"Search with Cliqz a" selected text popup action is opening new tab putting selected text in url bar and opening Cliqz search.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the code style of this project.
- [ ] I updated or created necessary unit tests
- [ ] I updated all necessary documentation
