### PR TITLE
Increate timeout for UserAgent test

### DIFF
--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -32,7 +32,7 @@ class ClientTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testDesktopUserAgent() {


### PR DESCRIPTION
Trying to solve the problem of shaky tests.