### PR TITLE
Search: Prevent autocomplete on backspace

### DIFF
--- a/ReactNative/NativeModules/AutoCompletion.swift
+++ b/ReactNative/NativeModules/AutoCompletion.swift
@@ -17,6 +17,14 @@ class AutoCompletion: NSObject {
                 return
             }
 
+            // don't call auto complete if user is backspacing
+            guard
+                let searchController = appDel.browserViewController.searchController,
+                !searchController.isLastCharacterRemoved
+            else {
+                return
+            }
+
             appDel.browserViewController.urlBar.setAutocompleteSuggestion(suggestion as String)
         }
     }

--- a/ReactNative/ViewControllers/SearchResultsViewController.swift
+++ b/ReactNative/ViewControllers/SearchResultsViewController.swift
@@ -17,6 +17,7 @@ import React
 ///     - add constraints for `.view`
 ///     - ALSO add constraints for `.searchView` (!!!)
 class SearchResultsViewController: UIViewController {
+    public var isLastCharacterRemoved = false
 
     // MARK: Properties
     public private(set) var lastQuery: String = ""
@@ -28,8 +29,10 @@ class SearchResultsViewController: UIViewController {
 
             if lastStringLength - searchQuery.count == 1 {
                 keyCode = "Backspace"
+                self.isLastCharacterRemoved = true
             } else if searchQuery.count > lastStringLength {
                 keyCode = "Key" + String(searchQuery.last!).uppercased()
+                self.isLastCharacterRemoved = false
             }
 
             lastQuery = searchQuery
@@ -95,7 +98,7 @@ extension SearchResultsViewController: BrowserCoreClient {
     private func startSearch(_ keyCode: String) {
         browserCore.callAction(module: "search", action: "startSearch", args: [
             searchQuery,
-            ["key": keyCode],
+            ["keyCode": keyCode],
             ["contextId": "mobile-cards"],
         ])
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Ticket
<!--- 
Add a reference to the ticket this PR relates to, if any. 
You can write 'Fixes #100' to auto close ticket #100 on merge.
Or write 'Re #100' to reference ticket #100 without changing its status.
-->

## Description
<!--- Describe your changes in detail -->
While typing the query search tries to autocomplete it to the first result.
This PR disable autocompletions when users try to correct the query by removing last character.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the code style of this project.
- [ ] I updated or created necessary unit tests
- [ ] I updated all necessary documentation
