### PR TITLE
Fix #5319 - Error in injected JS stops all JS from running

### DIFF
--- a/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/DownloadHelper.js
+++ b/Client/Frontend/UserContent/UserScripts/AllFrames/AtDocumentEnd/DownloadHelper.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
-
+if (typeof window.__firefox__.download == "undefined") {
 Object.defineProperty(window.__firefox__, "download", {
   enumerable: false,
   configurable: false,
@@ -45,7 +45,7 @@ Object.defineProperty(window.__firefox__, "download", {
     link.dispatchEvent(new MouseEvent("click"));
   }
 });
-
+}
 function getLastPathComponent(url) {
   return url.split("/").pop();
 }
@@ -58,3 +58,4 @@ function blobToBase64String(blob, callback) {
 
   reader.readAsDataURL(blob);
 }
+


### PR DESCRIPTION
Cherry-picking Download helper User Script fix
https://github.com/mozilla-mobile/firefox-ios/commit/52e120c83644891d0137655fa18e3ef81433d005


<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #359 

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
