### PR TITLE
Back button may triggers search 

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -7,7 +7,7 @@ import Shared
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         guard let tab = tabManager.selectedTab else { return }
-        if let query = tab.query {
+        if let url = tab.url, let query = tab.queries[url] {
             self.urlBar.enterOverlayMode(query, pasted: false, search: true)
             self.urlBar.onCancelAction = { tab.goBack() }
         } else {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -6,7 +6,13 @@ import Shared
 
 extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     func tabToolbarDidPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
-        tabManager.selectedTab?.goBack()
+        guard let tab = tabManager.selectedTab else { return }
+        if let query = tab.query {
+            self.urlBar.enterOverlayMode(query, pasted: false, search: true)
+            self.urlBar.onCancelAction = { tab.goBack() }
+        } else {
+            tab.goBack()
+        }
     }
 
     func tabToolbarDidLongPressBack(_ tabToolbar: TabToolbarProtocol, button: UIButton) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -72,6 +72,8 @@ class Tab: NSObject {
 
     var consecutiveCrashes: UInt = 0
 
+    var query: String?
+
     var canonicalURL: URL? {
         if let string = pageMetadata?.siteURL,
             let siteURL = URL(string: string) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -72,7 +72,7 @@ class Tab: NSObject {
 
     var consecutiveCrashes: UInt = 0
 
-    var query: String?
+    var queries: [URL: String] = [:]
 
     var canonicalURL: URL? {
         if let string = pageMetadata?.siteURL,

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -499,7 +499,10 @@ class URLBarView: UIView {
     }
 
     func leaveOverlayMode(didCancel cancel: Bool = false) {
-        self.onCancelAction?()
+        if self.onCancelAction != nil {
+            self.onCancelAction?()
+            self.onCancelAction = nil
+        }
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -52,6 +52,8 @@ protocol URLBarDelegate: AnyObject {
     func urlBarDidBeginDragInteraction(_ urlBar: URLBarView)
 }
 
+typealias CancelAction = () -> Void
+
 class URLBarView: UIView {
     // Additional UIAppearance-configurable properties
     @objc dynamic var locationBorderColor: UIColor = URLBarViewUX.TextFieldBorderColor {
@@ -84,6 +86,8 @@ class URLBarView: UIView {
 
     var toolbarIsShowing = false
     var topTabsIsShowing = false
+
+    var onCancelAction: CancelAction?
 
     fileprivate var locationTextField: ToolbarTextField?
 
@@ -495,6 +499,7 @@ class URLBarView: UIView {
     }
 
     func leaveOverlayMode(didCancel cancel: Bool = false) {
+        self.onCancelAction?()
         locationTextField?.resignFirstResponder()
         animateToOverlayState(overlayMode: false, didCancel: cancel)
         delegate?.urlBarDidLeaveOverlayMode(self)

--- a/ReactNative/NativeModules/BrowserActions.swift
+++ b/ReactNative/NativeModules/BrowserActions.swift
@@ -35,7 +35,7 @@ class BrowserActions: NSObject {
                     visitType: VisitType.link,
                     forTab: tab)
                 if query.length > 0 {
-                    tab.query = String(query)
+                    tab.queries[url] = String(query)
                 }
             }
         }

--- a/ReactNative/NativeModules/BrowserActions.swift
+++ b/ReactNative/NativeModules/BrowserActions.swift
@@ -27,8 +27,16 @@ class BrowserActions: NSObject {
                 url = URL(string: encodedString)
             }
 
-            if let url = url {
-                appDel.browserViewController.homePanel(didSelectURL: url, visitType: VisitType.link)
+            if
+                let url = url,
+                let tab = appDel.tabManager.selectedTab
+            {
+                appDel.browserViewController.finishEditingAndSubmit(url,
+                    visitType: VisitType.link,
+                    forTab: tab)
+                if query.length > 0 {
+                    tab.query = String(query)
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #365

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->
This feature is sometimes referred to as "Trampoline" as user bounces back to search. 
This simple implementation remembers just one query per tab and it forgets about queries on browser restart. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
