### PR TITLE
Hide keyboard on return keyboard if URL is not filled #369

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1329,46 +1329,7 @@ extension BrowserViewController: URLBarDelegate {
             return
         }
 
-        // TO DO : We need a `getURLForKeywordSearch` API in RustPlaces to
-        // handle the keyword search.
-        submitSearchText(text, forTab: currentTab)
-        /*
-        // We couldn't build a URL, so check for a matching search keyword.
-        let trimmedText = text.trimmingCharacters(in: .whitespaces)
-        guard let possibleKeywordQuerySeparatorSpace = trimmedText.index(of: " ") else {
-            submitSearchText(text, forTab: currentTab)
-            return
-        }
-
-        let possibleKeyword = String(trimmedText[..<possibleKeywordQuerySeparatorSpace])
-        let possibleQuery = String(trimmedText[trimmedText.index(after: possibleKeywordQuerySeparatorSpace)...])
-
-        let deferred = profile.bookmarks.getURLForKeywordSearch(possibleKeyword)
-        currentBookmarksKeywordQuery = deferred as? Cancellable
-
-        deferred.uponQueue(.main) { result in
-            defer {
-                self.currentBookmarksKeywordQuery = nil
-            }
-
-            guard let deferred = deferred as? Cancellable, !deferred.cancelled else {
-                return
-            }
-
-            if var urlString = result.successValue,
-                let escapedQuery = possibleQuery.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed),
-                let range = urlString.range(of: "%s") {
-                urlString.replaceSubrange(range, with: escapedQuery)
-
-                if let url = URL(string: urlString) {
-                    self.finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: currentTab)
-                    return
-                }
-            }
-
-            self.submitSearchText(text, forTab: currentTab)
-        }
-        */
+        self.urlBar.closeKeyboard()
     }
 
     fileprivate func submitSearchText(_ text: String, forTab tab: Tab) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -340,7 +340,7 @@ class URLBarView: UIView {
         updateShadow()
     }
 
-    func updateShadow() {
+    private func updateShadow() {
         let opacity: Double = inOverlayMode ? URLBarViewUX.LocationContainerShadowOpacity : 0.0
         let offset: CGSize = inOverlayMode ? URLBarViewUX.LocationContainerShadowOffset : .zero
         let duration: TimeInterval = inOverlayMode ? 0.3 : 0.1
@@ -368,7 +368,7 @@ class URLBarView: UIView {
         CATransaction.commit()
     }
 
-    func createLocationTextField() {
+    private func createLocationTextField() {
         guard locationTextField == nil else { return }
 
         locationTextField = ToolbarTextField()
@@ -400,14 +400,13 @@ class URLBarView: UIView {
         locationTextField.applyTheme()
         locationTextField.backgroundColor = .clear
         locationTextField.inputAccessoryView = querySuggestionsInputAccessoryView
-//        locationTextField.layer.cornerRadius = self.locationView.layer.cornerRadius
     }
 
     override func becomeFirstResponder() -> Bool {
         return self.locationTextField?.becomeFirstResponder() ?? false
     }
 
-    func removeLocationTextField() {
+    private func removeLocationTextField() {
         locationTextField?.removeFromSuperview()
         locationTextField = nil
     }
@@ -604,6 +603,10 @@ class URLBarView: UIView {
 
     @objc func tappedScrollToTopArea() {
         delegate?.urlBarDidPressScrollToTop(self)
+    }
+
+    func closeKeyboard() {
+        self.locationTextField?.resignFirstResponder()
     }
 }
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #369 

## Implementation details
- hiding keyboard when URL is not filled. Relying on firefox URIFixup.getURL implementation. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
