### PR TITLE
 Page actions order #374

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -462,7 +462,6 @@ extension Strings {
 extension Strings {
     public static let AppMenuShowTabsTitleString = NSLocalizedString("Menu.ShowTabs.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to open the tabs tray")
     public static let AppMenuSharePageTitleString = NSLocalizedString("Menu.SharePageAction.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to open the share dialog.")
-    public static let AppMenuCopyURLTitleString = NSLocalizedString("Menu.CopyAddress.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to copy the page url to the clipboard.")
     public static let AppMenuNewTabTitleString = NSLocalizedString("Menu.NewTabAction.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to open a new tab")
     public static let AppMenuNewPrivateTabTitleString = NSLocalizedString("Menu.NewPrivateTabAction.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to open a new private tab.")
     public static let AppMenuAddBookmarkTitleString = NSLocalizedString("Menu.AddBookmarkAction.Title", tableName: "Menu", comment: "Label for the button, displayed in the menu, used to create a bookmark for the current website.")

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -178,13 +178,6 @@ extension PhotonActionSheetProtocol {
             }
         }
 
-        let copyURL = PhotonActionSheetItem(title: Strings.AppMenuCopyURLTitleString, iconString: "menu-Copy-Link") { _ in
-            if let url = tab.canonicalURL?.displayURL {
-                UIPasteboard.general.url = url
-                success(Strings.AppMenuCopyURLConfirmMessage)
-            }
-        }
-
         var mainActions = [sharePage]
 
         // Disable bookmarking if the URL is too long.
@@ -192,12 +185,12 @@ extension PhotonActionSheetProtocol {
             mainActions.append(isBookmarked ? removeBookmark : bookmarkPage)
         }
 
-        mainActions.append(contentsOf: [copyURL])
+        let pinAction = (isPinned ? removeTopSitesPin : pinToTopSites)
+        mainActions.append(pinAction)
 
         let refreshPage = self.refreshPageItem()
 
-        let pinAction = (isPinned ? removeTopSitesPin : pinToTopSites)
-        var commonActions = [toggleDesktopSite, pinAction, refreshPage]
+        var commonActions = [toggleDesktopSite, refreshPage]
 
         // Disable find in page if document is pdf.
         if tab.mimeType != MIMEType.PDF {

--- a/Translations/de.lproj/Menu.strings
+++ b/Translations/de.lproj/Menu.strings
@@ -4,9 +4,6 @@
 /* Label for the button, displayed in the menu, used to close all tabs currently open. */
 "Menu.CloseAllTabsAction.Title" = "Alle Tabs schließen";
 
-/* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
-"Menu.CopyAddress.Title" = "Adresse kopieren";
-
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
 "Menu.FindInPageAction.Title" = "In Seite suchen";
 

--- a/Translations/en.lproj/Menu.strings
+++ b/Translations/en.lproj/Menu.strings
@@ -4,9 +4,6 @@
 /* Label for the button, displayed in the menu, used to close all tabs currently open. */
 "Menu.CloseAllTabsAction.Title" = "Close All Tabs";
 
-/* Label for the button, displayed in the menu, used to copy the page url to the clipboard. */
-"Menu.CopyAddress.Title" = "Copy Address";
-
 /* Label for the button, displayed in the menu, used to open the toolbar to search for text within the current page. */
 "Menu.FindInPageAction.Title" = "Find in Page";
 

--- a/XCUITests/ClipBoardTests.swift
+++ b/XCUITests/ClipBoardTests.swift
@@ -54,9 +54,9 @@ class ClipBoardTests: BaseTestCase {
     func testClipboardPasteAndGo() {
         navigator.openURL(url)
         waitUntilPageLoad()
-        navigator.goto(PageOptionsMenu)
-        print(app.debugDescription)
-        navigator.performAction(Action.CopyAddressPAM)
+        app.textFields["url"].press(forDuration: 3)
+        waitForExistence(app.tables["Context Menu"])
+        app.cells["menu-Copy-Link"].tap()
 
         checkCopiedUrl()
         navigator.createNewTab()


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #374 

## Implementation details
Removed Copy action from page action list.
Change page action list order.
Keep iPad functionality to show popover actions list reversed.
Fixed failed tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
