### PR TITLE
In this PR we fixed the following issue: "Downloading is completed popup's 'Downloads' button doesn't do anything." #383

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -39,6 +39,7 @@ protocol HomeViewControllerProtocol: Themeable {
     func scrollToTop(animated: Bool)
     func willMove(toParent parent: UIViewController?)
     func removeFromParent()
+    func switchView(segment: HomeViewController.Segment)
 }
 
 class BrowserViewController: UIViewController {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadQueueDelegate.swift
@@ -51,8 +51,9 @@ extension BrowserViewController: DownloadQueueDelegate {
             if error == nil {
                 let downloadCompleteToast = ButtonToast(labelText: download.filename, imageName: "check", buttonText: Strings.DownloadsButtonTitle, completion: { buttonPressed in
                     guard buttonPressed else { return }
-
-                    // Todo: #211 open download screen
+                    let newTab = self.tabManager.addTab()
+                    self.tabManager.selectTab(newTab)
+                    self.homeViewController?.switchView(segment: .downloads)
                 })
 
                 self.show(toast: downloadCompleteToast, duration: DispatchTimeInterval.seconds(8))

--- a/UserAgent/Home View/HomeViewController.swift
+++ b/UserAgent/Home View/HomeViewController.swift
@@ -18,7 +18,7 @@ class HomeViewController: UIViewController {
 
     fileprivate let profile: Profile
 
-    private enum Segment {
+    enum Segment {
         case topSites
         case bookmarks
         case history
@@ -165,6 +165,11 @@ extension HomeViewController: HomeViewControllerProtocol {
     func applyTheme() {
         view.backgroundColor = UIColor.theme.browser.background
         self.allViews.forEach({ ($0 as? Themeable)?.applyTheme() })
+    }
+
+    func switchView(segment: HomeViewController.Segment) {
+        self.showView(segment: segment)
+        self.segmentedControl.selectedSegmentIndex = self.segments.firstIndex(of: segment) ?? 0
     }
 
     func scrollToTop() {


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #383 

## Implementation details
Added functionality to open downloads list from download toast.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
