### PR TITLE
optimized  top sites refreshing logic #212

### DIFF
--- a/Client/Frontend/Home/PanelDataObservers.swift
+++ b/Client/Frontend/Home/PanelDataObservers.swift
@@ -40,7 +40,7 @@ class ActivityStreamDataObserver: DataObserver {
     let invalidationTime: UInt64
     weak var delegate: DataObserverDelegate?
 
-    fileprivate let events: [Notification.Name] = [.FirefoxAccountChanged, .ProfileDidFinishSyncing, .PrivateDataClearedHistory]
+    fileprivate let events: [Notification.Name] = [.PrivateDataClearedHistory]
 
     init(profile: Profile) {
         self.profile = profile
@@ -79,7 +79,7 @@ class ActivityStreamDataObserver: DataObserver {
 
     @objc func notificationReceived(_ notification: Notification) {
         switch notification.name {
-        case .ProfileDidFinishSyncing, .FirefoxAccountChanged, .PrivateDataClearedHistory:
+        case .PrivateDataClearedHistory:
              refreshIfNeeded(forceTopSites: true)
         default:
             log.warning("Received unexpected notification \(notification.name)")

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -524,9 +524,6 @@ class SettingsTableViewController: ThemedTableViewController {
         super.viewWillAppear(animated)
 
         settings = generateSettings()
-        NotificationCenter.default.addObserver(self, selector: #selector(syncDidChangeState), name: .ProfileDidStartSyncing, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(syncDidChangeState), name: .ProfileDidFinishSyncing, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(firefoxAccountDidChange), name: .FirefoxAccountChanged, object: nil)
 
         applyTheme()
     }
@@ -541,14 +538,6 @@ class SettingsTableViewController: ThemedTableViewController {
         refresh()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
-        [Notification.Name.ProfileDidStartSyncing, Notification.Name.ProfileDidFinishSyncing, Notification.Name.FirefoxAccountChanged].forEach { name in
-            NotificationCenter.default.removeObserver(self, name: name, object: nil)
-        }
-    }
-
     // Override to provide settings in subclasses
     func generateSettings() -> [SettingSection] {
         return []
@@ -561,10 +550,6 @@ class SettingsTableViewController: ThemedTableViewController {
     }
 
     @objc fileprivate func refresh() {
-        self.tableView.reloadData()
-    }
-
-    @objc func firefoxAccountDidChange() {
         self.tableView.reloadData()
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -119,9 +119,6 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
                 make.width.equalTo(width)
             }
         }
-
-        NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidFinishSyncing, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(stopRotateSyncIcon), name: .ProfileDidStartSyncing, object: nil)
     }
 
     func applyTheme() {

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -6,12 +6,6 @@ extension Notification.Name {
     public static let DataLoginDidChange = Notification.Name("DataLoginDidChange")
 
     // add a property to allow the observation of firefox accounts
-    public static let FirefoxAccountChanged = Notification.Name("FirefoxAccountChanged")
-
-    public static let FirefoxAccountProfileChanged = Notification.Name("FirefoxAccountProfileChanged")
-
-    public static let FirefoxAccountDeviceRegistrationUpdated = Notification.Name("FirefoxAccountDeviceRegistrationUpdated")
-
     public static let PrivateDataClearedHistory = Notification.Name("PrivateDataClearedHistory")
     public static let PrivateDataClearedDownloadedFiles = Notification.Name("PrivateDataClearedDownloadedFiles")
 
@@ -21,17 +15,11 @@ extension Notification.Name {
     // MARK: Notification UserInfo Keys
     public static let UserInfoKeyHasSyncableAccount = Notification.Name("UserInfoKeyHasSyncableAccount")
 
-    // Fired when the FxA account has been verified. This should only be fired by the FxALoginStateMachine.
-    public static let FirefoxAccountVerified = Notification.Name("FirefoxAccountVerified")
-
     // Fired when the login synchronizer has finished applying remote changes
     public static let DataRemoteLoginChangesWereApplied = Notification.Name("DataRemoteLoginChangesWereApplied")
 
     // Fired when a the page metadata extraction script has completed and is being passed back to the native client
     public static let OnPageMetadataFetched = Notification.Name("OnPageMetadataFetched")
-
-    public static let ProfileDidStartSyncing = Notification.Name("ProfileDidStartSyncing")
-    public static let ProfileDidFinishSyncing = Notification.Name("ProfileDidFinishSyncing")
 
     public static let DatabaseWasRecreated = Notification.Name("DatabaseWasRecreated")
     public static let DatabaseWasClosed = Notification.Name("DatabaseWasClosed")

--- a/UserAgent/Home View/HistoryView.swift
+++ b/UserAgent/Home View/HistoryView.swift
@@ -148,6 +148,7 @@ private extension HistoryView {
             self.tableView.deleteRows(at: [indexPath], with: .right)
             self.tableView.endUpdates()
             self.updateEmptyPanelState()
+            self.profile.history.setTopSitesNeedsInvalidation()
         }
     }
 

--- a/UserAgent/Home View/TopSitesView.swift
+++ b/UserAgent/Home View/TopSitesView.swift
@@ -36,8 +36,7 @@ class TopSitesView: UIView {
 // MARK: - Private Implementation
 private extension TopSitesView {
     private func setup() {
-        profile.panelDataObservers.activityStream.refreshIfNeeded(forceTopSites: true)
-
+        profile.panelDataObservers.activityStream.refreshIfNeeded(forceTopSites: false)
         _ = profile.history.getTopSitesWithLimit(8).both(
             profile.history.getPinnedTopSites()
             ).bindQueue(.main) { (topSites, pinned) -> Success in


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #212 

## Implementation details
- known issue - removing  history item will not propagate UI update in top sites immediately. Only next time you open a new page will update the list. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
