### PR TITLE
Fix Privacy Indicator label color

### DIFF
--- a/UserAgent/Views/Privacy Indicator/PrivacyDashboardView.swift
+++ b/UserAgent/Views/Privacy Indicator/PrivacyDashboardView.swift
@@ -215,7 +215,7 @@ private extension PrivacyDashboardView {
 
     func statLabel(labelled text: String) -> UILabel {
         let label = UILabel()
-        label.textColor = UIColor.Grey90
+        label.textColor = UIColor.theme.textField.textAndTint
         label.text = text
         label.numberOfLines = 0
         label.setContentCompressionResistancePriority(.required, for: .horizontal)


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
