### PR TITLE
Removed "Quick Search Engines" label in settings and hide the "Additional search engines" settings section for now #452

### DIFF
--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -41,7 +41,8 @@ class AppSettingsTableViewController: SettingsTableViewController {
             BoolSetting(prefs: prefs, defaultValue: self.currentAdultFilterMode == .conservative, titleText: Strings.SettingsAdultFilterMode, enabled: self.currentAdultFilterMode != nil) { (value) in
                 Search.setAdultFilter(filter: value ? .conservative : .liberal)
             },
-            SearchSetting(settings: self),
+            // Temporarily disabling additional search engines setting.
+//            SearchSetting(settings: self),
         ]
         settings += [ SettingSection(title: NSAttributedString(string: Strings.SettingsSearchSectionTitle), children: searchSettings)]
 

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -166,9 +166,7 @@ class SearchSettingsTableViewController: ThemedTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderIdentifier) as! ThemedTableSectionHeaderFooterView
-        headerView.titleLabel.text = NSLocalizedString("Quick-Search Engines", comment: "Title for quick-search engines settings section.")
-        return headerView
+        return nil
     }
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -670,9 +670,6 @@
 /* Show UserAgent Browser Privacy Policy page from the Privacy section in the settings.*/
 "Privacy Policy" = "Datenschutzerklärung";
 
-/* Title for quick-search engines settings section. */
-"Quick-Search Engines" = "Suchmaschinen für Schnellsuche";
-
 /* Accessibility label for the Reader View button */
 "Reader View" = "Leseansicht";
 

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -670,9 +670,6 @@
 /* Show UserAgent Browser Privacy Policy page from the Privacy section in the settings.*/
 "Privacy Policy" = "Privacy Policy";
 
-/* Title for quick-search engines settings section. */
-"Quick-Search Engines" = "Quick-Search Engines";
-
 /* Accessibility label for the Reader View button */
 "Reader View" = "Reader View";
 

--- a/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
+++ b/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
@@ -234,7 +234,13 @@
                   Identifier = "SearchSettingsUITests/testCustomSearchEngineAsDefaultIsNotEditable()">
                </Test>
                <Test
+                  Identifier = "SearchSettingsUITests/testCustomSearchEngineIsEditable()">
+               </Test>
+               <Test
                   Identifier = "SearchSettingsUITests/testDefaultSearchEngine()">
+               </Test>
+               <Test
+                  Identifier = "SearchSettingsUITests/testDeletingLastCustomEngineExitsEditing()">
                </Test>
                <Test
                   Identifier = "SearchSettingsUITests/testNavigateToSearchPickerTurnsOffEditing()">


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #452 

## Implementation details
Removed "Additional search engine" setting.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
