### PR TITLE
Set TintColor for HomeView Segmented Control

### DIFF
--- a/UserAgent/Home View/HomeViewController.swift
+++ b/UserAgent/Home View/HomeViewController.swift
@@ -92,6 +92,7 @@ private extension HomeViewController {
         showView(segment: .topSites)
         guard let segmentIndex = segments.firstIndex(of: .topSites) else { return }
         segmentedControl.selectedSegmentIndex = segmentIndex
+        segmentedControl.tintColor = UIColor.BrightBlue
     }
 
     func setupConstraints() {


### PR DESCRIPTION
This will affect the color in iOS 12

<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
