### PR TITLE
Fix layout bugs in Privacy Dashboard

### DIFF
--- a/UserAgent/Views/Privacy Indicator/PrivacyDashboardView.swift
+++ b/UserAgent/Views/Privacy Indicator/PrivacyDashboardView.swift
@@ -140,6 +140,11 @@ class PrivacyDashboardView: UIView {
 
 private extension PrivacyDashboardView {
     private func setup() {
+        snp.makeConstraints { make in
+            // This fixes a bug where the tableview would squash elements inside PrivacyDashboardView
+            make.height.greaterThanOrEqualTo(UIScreen.main.bounds.height * 0.3)
+        }
+
         backgroundColor = UIColor.clear
 
         let titleStackView = UIStackView(arrangedSubviews: [allTrackersSeenOnLabel, domainLabel])
@@ -148,6 +153,7 @@ private extension PrivacyDashboardView {
         let mainStackView = UIStackView(arrangedSubviews: [privacyIndicator, pageStatsListStackView])
         mainStackView.spacing = 10
         mainStackView.alignment = .top
+        mainStackView.distribution = .fillProportionally
 
         [titleStackView, mainStackView, numberOfTrackersLabel].forEach { addSubview($0) }
 
@@ -170,7 +176,6 @@ private extension PrivacyDashboardView {
             pageStatsListStackView.addArrangedSubview(stackView)
         }
 
-        pageStatsListStackView.addArrangedSubview(spacerView())
         pageStatsListStackView.addArrangedSubview(stackViewForNoTrackersSeen)
         pageStatsListStackView.addArrangedSubview(stackViewForWhiteListed)
 
@@ -184,7 +189,7 @@ private extension PrivacyDashboardView {
         }
 
         privacyIndicator.snp.makeConstraints { make in
-            make.width.equalToSuperview().dividedBy(2.2)
+            make.width.equalTo(mainStackView).dividedBy(2.2)
         }
 
         numberOfTrackersLabel.snp.makeConstraints { make in

--- a/UserAgent/Views/Privacy Indicator/PrivacyIndicatorView.swift
+++ b/UserAgent/Views/Privacy Indicator/PrivacyIndicatorView.swift
@@ -14,7 +14,7 @@ import Foundation
 class PrivacyIndicatorView: UIView {
     // MARK: - Properties
     /// Call this block whenever the user taps the Privacy Indicator
-    public var onTapBlock: (() -> Void)?
+    public var onTapBlock: (() -> Void)? { didSet {  button.isHidden = onTapBlock == nil }}
 
     /// The Blocker instance to take data from.
     ///
@@ -45,6 +45,7 @@ class PrivacyIndicatorView: UIView {
     private lazy var button: UIButton = {
         let button = UIButton()
         button.addTarget(self, action: #selector(didPressButton(_:)), for: .touchUpInside)
+        button.isHidden = onTapBlock == nil
         return button
     }()
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #464 

## Implementation details
Basically this is a workaround: The tableview's auto sizing sometimes tries to compress the view, making it as small as possible. For now, we force the view to have at least a certain height, preventing this display error. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
