### PR TITLE
fixed autoselection text with clear button overlapping problem

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -235,7 +235,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
         let enteredTextSize = self.attributedText?.boundingRect(with: self.frame.size, options: NSStringDrawingOptions.usesLineFragmentOrigin, context: nil)
         frame.origin.x = (enteredTextSize?.width.rounded() ?? 0)
-        frame.size.width = self.frame.size.width - frame.origin.x
+        let defaultCancelButtonWidth: CGFloat = (self.clearButtonMode == .whileEditing) ? 20 : 0
+        frame.size.width = self.frame.size.width - frame.origin.x - defaultCancelButtonWidth
         frame.size.height = self.frame.size.height - 1
         label.frame = frame
         return label


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #494 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
