### PR TITLE
Reader mode toolbar is visible while searching #516

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -772,6 +772,7 @@ class BrowserViewController: UIViewController {
         guard let searchController = self.searchController else {
             return
         }
+        self.view.bringSubviewToFront(self.overlayBackground)
 
         addChild(searchController)
         view.addSubview(searchController.view)


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #516 

## Implementation details
Fixed search background issue when reader mode is on.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
