### PR TITLE
 Privacy Dashboard: remove the statistics button from websites that have 0 trackers #491

### DIFF
--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -276,7 +276,7 @@ extension PhotonActionSheetProtocol {
 
         // Whotracks.me link
         guard let baseDomain = blocker.tab?.currentURL()?.baseDomain, let appDel = UIApplication.shared.delegate as? AppDelegate else {
-            return [menuActions, [trackerInfo], ]
+            return [menuActions, [trackerInfo]]
         }
 
         let whoTracksMeLink = PhotonActionSheetItem(title: Strings.PrivacyDashboard.ViewFullReport + " ›") { action in
@@ -287,8 +287,11 @@ extension PhotonActionSheetProtocol {
         if blocker.status == .Disabled {
             return [[whoTracksMeLink]]
         }
-
-        return [menuActions, [trackerInfo], [whoTracksMeLink]]
+        if blocker.stats.total > 0 {
+            return [menuActions, [trackerInfo], [whoTracksMeLink]]
+        } else {
+            return [menuActions, [trackerInfo]]
+        }
     }
 
     @available(iOS 11.0, *)


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #491 

## Implementation details
Removed statistical report button for websites that have 0 trackers.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
