### PR TITLE
Removing extra-hop

### DIFF
--- a/ReactNative/js/screens/SearchResults/components/Results.jsx
+++ b/ReactNative/js/screens/SearchResults/components/Results.jsx
@@ -231,7 +231,7 @@ class Results extends React.Component {
                 <TouchableWithoutFeedback
                   onPress={() =>
                     this.openSearchEngineLink(
-                      `https://google.com/search?q=${encodeURIComponent(
+                      `https://www.google.com/search?q=${encodeURIComponent(
                         query,
                       )}`,
                       0,


### PR DESCRIPTION
When the user hits the search with Google option, it goes to `https://google.com/search?q=1`.

On observing network call, I realised that `https://google.com` always sends a Location header for redirection to `https://www.google.com`.

This PR aims to avoid that one extra call per google query.

<img width="706" alt="Screenshot 2019-11-26 at 22 36 43" src="https://user-images.githubusercontent.com/10497229/69674658-3d258380-109d-11ea-83d7-e393832900c8.png">
