### PR TITLE
Temporary disabled add custom search engine button from keyboard input view #537

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2076,6 +2076,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
             self.alertStackView.layoutIfNeeded()
         }
 
+        // Temporarily disabling add custom search engine button from keyboard input view, as additional search engines setting is disabled.
+        // Also there are crashes related to that button: https://sentry.io/organizations/cliqz/issues/1357579323/?referrer=github_integration
+        /*
         guard let webView = tabManager.selectedTab?.webView else {
             return
         }
@@ -2085,6 +2088,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
             }
             self.addCustomSearchButtonToWebView(webView)
         }
+        */
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #537 

## Implementation details
Removed add search engine button from keyboard input view.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
