### PR TITLE
Disabled "Paste & Go" action if copied string isn't valid URL #580

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -312,7 +312,12 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 extension AutocompleteTextField: MenuHelperInterface {
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == MenuHelper.SelectorPasteAndGo {
-            return UIPasteboard.general.hasStrings
+            guard UIPasteboard.general.hasStrings, let string = UIPasteboard.general.string else {
+                return false
+            }
+            let isFixupURL = URIFixup.getURL(string) != nil
+            let isValidURL = URL(string: string)?.schemeIsValid == true
+            return isFixupURL || isValidURL
         }
 
         return super.canPerformAction(action, withSender: sender)


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #580 

## Implementation details
Disabled "Paste & Go" action if copied string isn't URL.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
