### PR TITLE
Disabled Paste & Go for queries #580

### DIFF
--- a/Client/Extensions/UIPasteboardExtensions.swift
+++ b/Client/Extensions/UIPasteboardExtensions.swift
@@ -7,6 +7,14 @@ import Shared
 import UIKit
 
 extension UIPasteboard {
+
+    var isCopiedStringValidURL: Bool {
+        guard self.hasStrings, let string = UIPasteboard.general.string else {
+            return false
+        }
+        return URIFixup.getURL(string) != nil || URL(string: string)?.schemeIsValid == true
+    }
+
     func addImageWithData(_ data: Data, forURL url: URL) {
         let isGIF = data.isGIF
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1282,7 +1282,10 @@ extension BrowserViewController: URLBarDelegate {
 
     func locationActionsForURLBar(_ urlBar: URLBarView) -> [AccessibleAction] {
         if UIPasteboard.general.string != nil {
-            return [pasteGoAction, pasteAction, copyAddressAction]
+            if UIPasteboard.general.isCopiedStringValidURL {
+                return [pasteGoAction, pasteAction, copyAddressAction]
+            }
+            return [pasteAction, copyAddressAction]
         } else {
             return [copyAddressAction]
         }

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -312,12 +312,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 extension AutocompleteTextField: MenuHelperInterface {
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == MenuHelper.SelectorPasteAndGo {
-            guard UIPasteboard.general.hasStrings, let string = UIPasteboard.general.string else {
-                return false
-            }
-            let isFixupURL = URIFixup.getURL(string) != nil
-            let isValidURL = URL(string: string)?.schemeIsValid == true
-            return isFixupURL || isValidURL
+            return UIPasteboard.general.isCopiedStringValidURL
         }
 
         return super.canPerformAction(action, withSender: sender)

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -312,7 +312,12 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 extension AutocompleteTextField: MenuHelperInterface {
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == MenuHelper.SelectorPasteAndGo {
-            return UIPasteboard.general.hasStrings
+            guard UIPasteboard.general.hasStrings, let string = UIPasteboard.general.string else {
+                return false
+            }
+            let isFixupURL = URIFixup.getURL(string) != nil
+            let isValidURL = URL(string: string)?.schemeIsValid == true
+            return isFixupURL || isValidURL
         }
 
         return super.canPerformAction(action, withSender: sender)

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -227,26 +227,28 @@ extension PhotonActionSheetProtocol {
     }
 
     func getLongPressLocationBarActions(with urlBar: URLBarView) -> [PhotonActionSheetItem] {
-        let pasteGoAction = PhotonActionSheetItem(title: Strings.Menu.PasteAndGoTitle, iconString: "menu-PasteAndGo") { action in
-            if let pasteboardContents = UIPasteboard.general.string {
-                urlBar.delegate?.urlBar(urlBar, didSubmitText: pasteboardContents, completion: nil)
+        let copyAddressAction = PhotonActionSheetItem(title: Strings.Menu.CopyAddressTitle, iconString: "menu-Copy-Link") { action in
+            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
+                UIPasteboard.general.url = url
             }
+        }
+        guard let string = UIPasteboard.general.string else {
+            return [copyAddressAction]
+        }
+        var actions = [PhotonActionSheetItem]()
+        if UIPasteboard.general.isCopiedStringValidURL {
+            let pasteGoAction = PhotonActionSheetItem(title: Strings.Menu.PasteAndGoTitle, iconString: "menu-PasteAndGo") { action in
+                urlBar.delegate?.urlBar(urlBar, didSubmitText: string, completion: nil)
+            }
+            actions.append(pasteGoAction)
         }
         let pasteAction = PhotonActionSheetItem(title: Strings.Menu.PasteTitle, iconString: "menu-Paste") { action in
             if let pasteboardContents = UIPasteboard.general.string {
                 urlBar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
             }
         }
-        let copyAddressAction = PhotonActionSheetItem(title: Strings.Menu.CopyAddressTitle, iconString: "menu-Copy-Link") { action in
-            if let url = self.tabManager.selectedTab?.canonicalURL?.displayURL ?? urlBar.currentURL {
-                UIPasteboard.general.url = url
-            }
-        }
-        if UIPasteboard.general.string != nil {
-            return [pasteGoAction, pasteAction, copyAddressAction]
-        } else {
-            return [copyAddressAction]
-        }
+        actions.append(contentsOf: [pasteAction, copyAddressAction])
+        return actions
     }
 
     @available(iOS 11.0, *)

--- a/Client/Helpers/MenuHelper.swift
+++ b/Client/Helpers/MenuHelper.swift
@@ -53,6 +53,10 @@ open class MenuHelper: NSObject {
         let searchTitle = String(format: NSLocalizedString("UIMenuItem.SearchWithUserAgent", value: "Search with Firefox", comment: "Search in New Tab Text selection menu item"), AppInfo.displayName)
         let searchItem = UIMenuItem(title: searchTitle, action: MenuHelper.SelectorSearchWithFirefox)
 
-        UIMenuController.shared.menuItems = [pasteAndGoItem, copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem, findInPageItem, searchItem]
+        if UIPasteboard.general.isCopiedStringValidURL {
+            UIMenuController.shared.menuItems = [pasteAndGoItem, copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem, findInPageItem, searchItem]
+        } else {
+            UIMenuController.shared.menuItems = [copyItem, revealPasswordItem, hidePasswordItem, openAndFillItem, findInPageItem, searchItem]
+        }
     }
 }

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		2B473CF2239637DE00442059 /* UseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CF0239637DE00442059 /* UseCases.swift */; };
 		2B473CF42396387B00442059 /* TabBarUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CF32396387B00442059 /* TabBarUseCases.swift */; };
 		2B473CF52396387B00442059 /* TabBarUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CF32396387B00442059 /* TabBarUseCases.swift */; };
+		2B4EFBDD239E6F53007A10E0 /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		2B516D2F238BAC8B006D6B57 /* DownloadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B516D28238BAC8B006D6B57 /* DownloadsViewController.swift */; };
 		2B516D30238BAC8B006D6B57 /* DownloadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B516D28238BAC8B006D6B57 /* DownloadsViewController.swift */; };
 		2B516D31238BAC8B006D6B57 /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B516D2A238BAC8B006D6B57 /* DownloadsView.swift */; };
@@ -4887,6 +4888,7 @@
 				3B39EDBA1E16E18900EF029F /* CustomSearchEnginesTest.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
+				2B4EFBDD239E6F53007A10E0 /* URIFixup.swift in Sources */,
 				DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */,
 				E683F0A61E92E0820035D990 /* MockableHistory.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #580 

## Implementation details
Disabled "Paste & Go" for invalid copied strings.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
