### PR TITLE
Chagned "What's new" page presentation #185

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadsDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+DownloadsDelegate.swift
@@ -23,9 +23,7 @@ extension BrowserViewController: DownloadsDelegate {
     }
 
     func downloadsDidClose() {
-        UIView.animate(withDuration: 1.0) {
-            self.view.window?.backgroundColor = Theme.browser.background
-        }
+        self.setPhoneWindowBackground(color: Theme.browser.background, animationDuration: 1.0)
     }
 
 }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -46,8 +46,9 @@ extension PhotonActionSheetProtocol {
         }
 
         let openDownloadsItem = self.openDownloadsItem(vcDelegate: vcDelegate)
+        let openWhatsNewtem = self.openWhatsNewItem(vcDelegate: vcDelegate)
 
-        return [openHomePage, openDownloadsItem]
+        return [openHomePage, openWhatsNewtem, openDownloadsItem]
     }
 
     /*
@@ -60,7 +61,6 @@ extension PhotonActionSheetProtocol {
 
     func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
         return [
-            self.openWhatsNewItem(vcDelegate: vcDelegate),
             self.openPrivacyStatementItem(vcDelegate: vcDelegate),
             self.openSettingsItem(vcDelegate: vcDelegate),
         ]
@@ -349,13 +349,8 @@ extension PhotonActionSheetProtocol {
     private func openWhatsNewItem(vcDelegate: PageOptionsVC) -> PhotonActionSheetItem {
         let badgeIconName: String? = (self.profile.prefs.boolForKey(PrefsKeys.WhatsNewBubble) == nil) ? "menuBadge" : nil
         let openSettings = PhotonActionSheetItem(title: Strings.Menu.WhatsNewTitleString, iconString: "menu-whatsNew", isEnabled: badgeIconName != nil, badgeIconNamed: badgeIconName) { action in
-            guard let url = URL(string: Strings.WhatsNewWebsite) else {
-                return
-            }
             self.profile.prefs.setBool(true, forKey: PrefsKeys.WhatsNewBubble)
-            (vcDelegate as? BrowserViewController)?.updateWhatsNewBadge()
-            let newTab = self.tabManager.addTab(URLRequest(url: url))
-            self.tabManager.selectTab(newTab)
+            (vcDelegate as? BrowserViewController)?.presentWhatsNewViewController()
         }
         return openSettings
     }

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -22,6 +22,7 @@ extension Strings {
         public static let OKString = NSLocalizedString("OK", comment: "OK button")
         public static let CancelString = NSLocalizedString("Cancel", comment: "Label for Cancel button")
         public static let OpenSettingsString = NSLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7")
+        public static let CloseString = NSLocalizedString("Close", comment: "Lable for Close button")
     }
 
     // MARK: - Table date section titles

--- a/UserAgent/Library/DownloadsViewController.swift
+++ b/UserAgent/Library/DownloadsViewController.swift
@@ -31,7 +31,6 @@ class DownloadsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.presentationController?.delegate = self
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.DownloadsPanel.DoneTitle, style: .done, target: self, action: #selector(closeButtonAction))
         self.title = Strings.Menu.DownloadsTitleString
         self.view.addSubview(self.downloadsView)
@@ -79,14 +78,6 @@ extension DownloadsViewController: UIDocumentInteractionControllerDelegate {
 
     func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
         return self
-    }
-
-}
-
-extension DownloadsViewController: UIAdaptivePresentationControllerDelegate {
-
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        self.delegate?.downloadsDidClose()
     }
 
 }

--- a/UserAgent/Views/PrivacyStatement/PrivacyStatementViewController.swift
+++ b/UserAgent/Views/PrivacyStatement/PrivacyStatementViewController.swift
@@ -48,7 +48,6 @@ class PrivacyStatementViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.presentationController?.delegate = self
         self.tableView.estimatedRowHeight = 44.0
         self.tableView.backgroundColor = UIColor.Grey20
         self.tableView.separatorStyle = .none
@@ -282,14 +281,6 @@ extension PrivacyStatementViewController: MFMailComposeViewControllerDelegate {
 
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true)
-    }
-
-}
-
-extension PrivacyStatementViewController: UIAdaptivePresentationControllerDelegate {
-
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        self.delegate?.privacyStatementViewControllerDidClose()
     }
 
 }


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #185 

## Implementation details
Chagned to present new controller with "What's New" url instead of opening new tab.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
