### PR TITLE
Added long press event on search icons to show list of previous queries #637

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -120,6 +120,10 @@ class BrowserViewController: UIViewController {
     var topTabsViewController: TopTabsViewController?
     let topTabsContainer = UIView()
 
+    // Keep last 5 queries.
+    // This list will be presented if user will long press on search icon.
+    var queries = [String]()
+
     // Keep track of allowed `URLRequest`s from `webView(_:decidePolicyFor:decisionHandler:)` so
     // that we can obtain the originating `URLRequest` when a `URLResponse` is received. This will
     // allow us to re-trigger the `URLRequest` if the user requests a file to be downloaded.
@@ -897,6 +901,9 @@ class BrowserViewController: UIViewController {
        }
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
+        if let query = self.searchController?.searchQuery {
+            self.appendQuery(query: query)
+        }
         currentBookmarksKeywordQuery?.cancel()
 
         urlBar.currentURL = url
@@ -1403,8 +1410,16 @@ extension BrowserViewController: URLBarDelegate {
             finishEditingAndSubmit(fixupURL, visitType: VisitType.typed, forTab: currentTab)
             return
         }
-
+        self.appendQuery(query: text)
         self.urlBar.closeKeyboard()
+    }
+
+    private func appendQuery(query: String) {
+        guard !self.queries.contains(query) else {
+            return
+        }
+        self.queries.insert(query, at: 0)
+        self.queries = Array(self.queries.prefix(5))
     }
 
     fileprivate func submitSearchText(_ text: String, forTab tab: Tab) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -61,6 +61,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         self.focusLocationTextField(forTab: self.tabManager.selectedTab)
     }
 
+    func tabToolbarDidLongPressSearch(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        self.showQueriesList(tabToolbar, button: button)
+    }
+
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         showTabTray()
     }
@@ -127,4 +131,18 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
             self.present(backForwardViewController, animated: true, completion: nil)
         }
     }
+
+    func showQueriesList(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        guard !self.queries.isEmpty else {
+            return
+        }
+        let queriesItems = self.getQueriesActions(queries: self.queries, didSelectQuery: { (query) in
+            self.urlBar.enterOverlayMode(query, pasted: false, search: true)
+        }) { (query) in
+            self.queries = self.queries.filter({ $0 != query })
+        }
+        let shouldSuppress = !self.topTabsVisible && UIDevice.current.isPad
+        self.presentSheetWith(actions: [queriesItems], on: self, from: button, suppressPopover: shouldSuppress)
+    }
+
 }

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -136,10 +136,13 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         guard !self.queries.isEmpty else {
             return
         }
-        let queriesItems = self.getQueriesActions(queries: self.queries, didSelectQuery: { (query) in
-            self.urlBar.enterOverlayMode(query, pasted: false, search: true)
-        }) { (query) in
-            self.queries = self.queries.filter({ $0 != query })
+        let queriesItems = self.getQueriesActions(queries: self.queries, didSelectQuery: { [weak self] (query) in
+            self?.urlBar.enterOverlayMode(query, pasted: false, search: true)
+        }) { [weak self] (query) in
+            self?.queries = self?.queries.filter({ $0 != query }) ?? []
+            if self?.queries.isEmpty ?? false {
+                self?.presentedViewController?.dismiss(animated: true)
+            }
         }
         let shouldSuppress = !self.topTabsVisible && UIDevice.current.isPad
         self.presentSheetWith(actions: [queriesItems], on: self, from: button, suppressPopover: shouldSuppress)

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -37,6 +37,7 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidLongPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressSearch(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidLongPressSearch(_ tabToolbar: TabToolbarProtocol, button: UIButton)
 }
 
 @objcMembers
@@ -84,6 +85,8 @@ open class TabToolbarHelper: NSObject {
 
         toolbar.searchButton.setImage(UIImage.templateImageNamed("search"), for: .normal)
         toolbar.searchButton.addTarget(self, action: #selector(didClickSearch), for: .touchUpInside)
+        let longPressGestureSearchButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressSearch))
+        toolbar.searchButton.addGestureRecognizer(longPressGestureSearchButton)
 
         toolbar.tabsButton.addTarget(self, action: #selector(didClickTabs), for: .touchUpInside)
         let longPressGestureTabsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTabs))
@@ -114,6 +117,12 @@ open class TabToolbarHelper: NSObject {
     func didLongPressTabs(_ recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == .began {
             toolbar.tabToolbarDelegate?.tabToolbarDidLongPressTabs(toolbar, button: toolbar.tabsButton)
+        }
+    }
+
+    func didLongPressSearch(_ recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == .began {
+            toolbar.tabToolbarDelegate?.tabToolbarDidLongPressSearch(toolbar, button: toolbar.searchButton)
         }
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -280,11 +280,31 @@ class PhotonActionSheet: UIViewController, UITableViewDelegate, UITableViewDataS
         }
     }
 
+    private func configureRemoveActionIfNeeded(for cell: PhotonActionSheetCell, action: PhotonActionSheetItem) {
+        if action.accessory == .Remove {
+            cell.didRemove = { [weak self] cell in
+                if let indexPath = self?.tableView.indexPath(for: cell), let action = self?.actions[indexPath.section][indexPath.row] {
+                    self?.actions[indexPath.section].remove(at: indexPath.row)
+                    CATransaction.begin()
+                    self?.tableView.beginUpdates()
+                    CATransaction.setCompletionBlock {
+                        self?.view.setNeedsLayout()
+                    }
+                    self?.tableView.deleteRows(at: [indexPath], with: .left)
+                    self?.tableView.endUpdates()
+                    CATransaction.commit()
+                    action.didRemoveHandler?(action)
+                }
+            }
+        }
+    }
+
     private func photonActionSheetCell(for action: PhotonActionSheetItem,
                                        _ tableView: UITableView, _ indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: PhotonActionSheetUX.CellName, for: indexPath) as! PhotonActionSheetCell
         cell.tintColor = self.tintColor
         cell.configure(with: action)
+        self.configureRemoveActionIfNeeded(for: cell, action: action)
         return cell
     }
 

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -272,7 +272,8 @@ class PhotonActionSheetCell: UITableViewCell {
             return
         }
         self.removeButton = UIButton()
-        self.removeButton.setImage(UIImage(named: "clear"), for: .normal)
+        self.removeButton.setImage(UIImage(named: "clear")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        self.removeButton.tintColor = self.tintColor
         self.removeButton.addTarget(self, action: #selector(PhotonActionSheetCell.removeButtonAction), for: .touchUpInside)
         self.stackView.addArrangedSubview(self.removeButton)
         self.removeButton.snp.makeConstraints { (make) in

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetCell.swift
@@ -28,6 +28,8 @@ class PhotonActionSheetCell: UITableViewCell {
 
     var badgeOverlay: BadgeWithBackdrop?
 
+    var didRemove: ((UITableViewCell) -> Void)?
+
     private func createLabel() -> UILabel {
         let label = UILabel()
         label.minimumScaleFactor = 0.75 // Scale the font if we run out of space
@@ -96,6 +98,8 @@ class PhotonActionSheetCell: UITableViewCell {
 
     let toggleSwitch = ToggleSwitch()
 
+    var removeButton: UIButton!
+
     lazy var selectedOverlay: UIView = {
         let selectedOverlay = UIView()
         selectedOverlay.backgroundColor = PhotonActionSheetCellUX.SelectedOverlayColor
@@ -127,6 +131,8 @@ class PhotonActionSheetCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.statusIcon.image = nil
+        self.removeButton?.removeFromSuperview()
+        self.removeButton = nil
         disclosureIndicator.removeFromSuperview()
         disclosureLabel.removeFromSuperview()
         toggleSwitch.mainView.removeFromSuperview()
@@ -253,9 +259,30 @@ class PhotonActionSheetCell: UITableViewCell {
         case .Switch:
             toggleSwitch.setOn(action.isEnabled)
             stackView.addArrangedSubview(toggleSwitch.mainView)
+        case .Remove:
+            self.addRemoveButton()
         default:
             break // Do nothing. The rest are not supported yet.
         }
         action.customRender?(titleLabel, contentView)
     }
+
+    private func addRemoveButton() {
+        guard self.removeButton == nil else {
+            return
+        }
+        self.removeButton = UIButton()
+        self.removeButton.setImage(UIImage(named: "clear"), for: .normal)
+        self.removeButton.addTarget(self, action: #selector(PhotonActionSheetCell.removeButtonAction), for: .touchUpInside)
+        self.stackView.addArrangedSubview(self.removeButton)
+        self.removeButton.snp.makeConstraints { (make) in
+            make.width.equalTo(self.removeButton.snp.height)
+            make.height.equalTo(self.stackView)
+        }
+    }
+
+    @objc func removeButtonAction() {
+        self.didRemove?(self)
+    }
+
 }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -59,6 +59,17 @@ extension PhotonActionSheetProtocol {
 
     typealias PageOptionsVC = SettingsDelegate & PresentingModalViewControllerDelegate & UIViewController
 
+    func getQueriesActions(queries: [String], didSelectQuery: @escaping (String) -> Void, didRemoveQuery: @escaping (String) -> Void) -> [PhotonActionSheetItem] {
+        var queryItems = [PhotonActionSheetItem]()
+        for query in queries {
+            let queryItem = PhotonActionSheetItem(title: query, iconString: "") { item in
+                didSelectQuery(item.title)
+            }
+            queryItems.append(queryItem)
+        }
+        return queryItems
+    }
+
     func getOtherPanelActions(vcDelegate: PageOptionsVC) -> [PhotonActionSheetItem] {
         return [
             self.openPrivacyStatementItem(vcDelegate: vcDelegate),

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -62,8 +62,11 @@ extension PhotonActionSheetProtocol {
     func getQueriesActions(queries: [String], didSelectQuery: @escaping (String) -> Void, didRemoveQuery: @escaping (String) -> Void) -> [PhotonActionSheetItem] {
         var queryItems = [PhotonActionSheetItem]()
         for query in queries {
-            let queryItem = PhotonActionSheetItem(title: query, iconString: "") { item in
+            var queryItem = PhotonActionSheetItem(title: query, accessory: .Remove) { item in
                 didSelectQuery(item.title)
+            }
+            queryItem.didRemoveHandler = { item in
+                didRemoveQuery(item.title)
             }
             queryItems.append(queryItem)
         }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetWidgets.swift
@@ -40,6 +40,7 @@ public enum PhotonActionSheetCellAccessoryType {
     case Switch
     case Text
     case Sync // Sync is a special case.
+    case Remove
     case None
 }
 
@@ -78,11 +79,12 @@ public struct PhotonActionSheetItem {
     // Enable height customization
     public var customHeight: ((PhotonActionSheetItem) -> CGFloat)?
 
+    public var didRemoveHandler: ((PhotonActionSheetItem) -> Void)?
+
     init(title: String, text: String? = nil, iconString: String? = nil, iconURL: URL? = nil, iconType: PhotonActionSheetIconType = .Image,
          iconAlignment: IconAlignment = .left, isEnabled: Bool = false, accessory: PhotonActionSheetCellAccessoryType = .None,
          accessoryText: String? = nil, badgeIconNamed: String? = nil, bold: Bool? = false, tabCount: String? = nil,
          customView: UIView? = nil, handler: ((PhotonActionSheetItem) -> Void)? = nil) {
-
         self.title = title
         self.iconString = iconString
         self.iconURL = iconURL


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #637 

## Implementation details
Added long press event on search icon to show list of previews queries.
Added ability to remove query from queries list.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
