### PR TITLE
Disabled record queries in forget mode #651

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -901,7 +901,7 @@ class BrowserViewController: UIViewController {
        }
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
-        if let query = self.searchController?.searchQuery {
+        if let query = self.searchController?.searchQuery, !tab.isPrivate {
             self.appendQuery(query: query)
         }
         currentBookmarksKeywordQuery?.cancel()
@@ -1410,7 +1410,9 @@ extension BrowserViewController: URLBarDelegate {
             finishEditingAndSubmit(fixupURL, visitType: VisitType.typed, forTab: currentTab)
             return
         }
-        self.appendQuery(query: text)
+        if !currentTab.isPrivate {
+            self.appendQuery(query: text)
+        }
         self.urlBar.closeKeyboard()
     }
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #651 

## Implementation details
Disabled queries collecting in forgot mode.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
