### PR TITLE
Tapping on News image should load page #648

### DIFF
--- a/ReactNative/js/screens/Home/components/News.jsx
+++ b/ReactNative/js/screens/Home/components/News.jsx
@@ -57,15 +57,16 @@ const useNews = newsModule => {
   return data;
 };
 
-const HiddableImage = ({ style, url }) => {
-  const [isHidden, setHidden] = useState(false, [url]);
+const HiddableImage = (props) => {
+  const { style, source } = props;
+  const [isHidden, setHidden] = useState(false, [source]);
   const hide = useCallback(() => setHidden(true), [setHidden]);
   const hiddenStyle = useMemo(
     () => (isHidden ? { height: 0, marginBottom: 0 } : null),
     [isHidden],
   );
   return (
-    <Image style={[style, hiddenStyle]} source={{ uri: url }} onError={hide} />
+    <Image {...props} style={[style, hiddenStyle]} source={{ uri: source }} onError={hide} />
   );
 };
 
@@ -92,7 +93,7 @@ export default function News({ newsModule, isImagesEnabled }) {
             <TouchableWithoutFeedback
               onPress={() => openLink(item.url)}
             >
-              <HiddableImage style={styles.image} url={item.imageUrl} />
+              <HiddableImage style={styles.image} source={item.imageUrl} />
             </TouchableWithoutFeedback>
           }
           <ListItem


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #
https://facebook.github.io/react-native/docs/touchablewithoutfeedback

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
