### PR TITLE
Add google back to list of additional search engines

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -157,7 +157,7 @@ class SearchEngines {
     }
 
     fileprivate func resetDisabledEngineNamesIfNeeded() {
-        let defaultEnabledEnginesIDs = ["google-b-1-m", "bing", "ddg"]
+        let defaultEnabledEnginesIDs = ["google-b-m", "google-b-1-m", "bing", "ddg"]
         let reset = self.prefs.boolForKey(ResetDisabledEngineNames)
         if reset == nil || !reset! {
             var disabledNames = [String]()


### PR DESCRIPTION
In some regions Google SERP has a different identifier, it has to be on the whitelist.