### PR TITLE
Bring back Authenticator - fix #665

### DIFF
--- a/Client/Frontend/Browser/Authenticator.swift
+++ b/Client/Frontend/Browser/Authenticator.swift
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Storage
+
+private let CancelButtonTitle = NSLocalizedString("Cancel", comment: "Label for Cancel button")
+private let LogInButtonTitle  = NSLocalizedString("Log in", comment: "Authentication prompt log in button")
+private let log = Logger.browserLogger
+
+class LoginRecord {
+    var credentials: URLCredential?
+    var protectionSpace: URLProtectionSpace?
+
+    init(credentials: URLCredential, protectionSpace: URLProtectionSpace) {
+        self.credentials = credentials
+        self.protectionSpace = protectionSpace
+    }
+}
+
+public class LoginRecordError: MaybeErrorType {
+    public let description: String
+    public init(description: String) {
+        self.description = description
+    }
+}
+
+class Authenticator {
+    fileprivate static let MaxAuthenticationAttempts = 3
+
+    static func handleAuthRequest(_ viewController: UIViewController, challenge: URLAuthenticationChallenge) -> Deferred<Maybe<LoginRecord>> {
+        // If there have already been too many login attempts, we'll just fail.
+        if challenge.previousFailureCount >= Authenticator.MaxAuthenticationAttempts {
+            return deferMaybe(LoginRecordError(description: "Too many attempts to open site"))
+        }
+
+        var credential = challenge.proposedCredential
+
+        // If we were passed an initial set of credentials from iOS, try and use them.
+        if let proposed = credential {
+            if !(proposed.user?.isEmpty ?? true) {
+                if challenge.previousFailureCount == 0 {
+                    return deferMaybe(LoginRecord(credentials: proposed, protectionSpace: challenge.protectionSpace))
+                }
+            } else {
+                credential = nil
+            }
+        }
+
+        // If we have some credentials, we'll show a prompt with them.
+        if let credential = credential {
+            return promptForUsernamePassword(viewController, credentials: credential, protectionSpace: challenge.protectionSpace)
+        }
+
+        // No credentials, so show an empty prompt.
+        return self.promptForUsernamePassword(viewController, credentials: nil, protectionSpace: challenge.protectionSpace)
+    }
+
+    fileprivate static func promptForUsernamePassword(_ viewController: UIViewController, credentials: URLCredential?, protectionSpace: URLProtectionSpace) -> Deferred<Maybe<LoginRecord>> {
+        if protectionSpace.host.isEmpty {
+            print("Unable to show a password prompt without a hostname")
+            return deferMaybe(LoginRecordError(description: "Unable to show a password prompt without a hostname"))
+        }
+
+        let deferred = Deferred<Maybe<LoginRecord>>()
+        let alert: AlertController
+        let title = NSLocalizedString("Authentication required", comment: "Authentication prompt title")
+        if !(protectionSpace.realm?.isEmpty ?? true) {
+            let msg = NSLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string")
+            let formatted = NSString(format: msg as NSString, protectionSpace.host, protectionSpace.realm ?? "") as String
+            alert = AlertController(title: title, message: formatted, preferredStyle: .alert)
+        } else {
+            let msg = NSLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site")
+            let formatted = NSString(format: msg as NSString, protectionSpace.host) as String
+            alert = AlertController(title: title, message: formatted, preferredStyle: .alert)
+        }
+
+        // Add a button to log in.
+        let action = UIAlertAction(title: LogInButtonTitle,
+                                   style: .default) { (action) -> Void in
+                                    guard let user = alert.textFields?[0].text, let pass = alert.textFields?[1].text else { deferred.fill(Maybe(failure: LoginRecordError(description: "Username and Password required"))); return }
+
+                                    let login = LoginRecord(credentials: URLCredential(user: user, password: pass, persistence: .forSession), protectionSpace: protectionSpace)
+                                    deferred.fill(Maybe(success: login))
+        }
+        alert.addAction(action, accessibilityIdentifier: "authenticationAlert.loginRequired")
+
+        // Add a cancel button.
+        let cancel = UIAlertAction(title: CancelButtonTitle, style: .cancel) { (action) -> Void in
+            deferred.fill(Maybe(failure: LoginRecordError(description: "Save password cancelled")))
+        }
+        alert.addAction(cancel, accessibilityIdentifier: "authenticationAlert.cancel")
+
+        // Add a username textfield.
+        alert.addTextField { (textfield) -> Void in
+            textfield.placeholder = NSLocalizedString("Username", comment: "Username textbox in Authentication prompt")
+            textfield.text = credentials?.user
+        }
+
+        // Add a password textfield.
+        alert.addTextField { (textfield) -> Void in
+            textfield.placeholder = NSLocalizedString("Password", comment: "Password textbox in Authentication prompt")
+            textfield.isSecureTextEntry = true
+            textfield.text = credentials?.password
+        }
+
+        viewController.present(alert, animated: true) { () -> Void in }
+        return deferred
+    }
+
+}

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -601,6 +601,14 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // The challenge may come from a background tab, so ensure it's the one visible.
         tabManager.selectTab(tab)
+
+        Authenticator.handleAuthRequest(self, challenge: challenge).uponQueue(.main) { res in
+            if let credentials = res.successValue {
+                completionHandler(.useCredential, credentials.credentials)
+            } else {
+                completionHandler(.rejectProtectionSpace, nil)
+            }
+        }
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -254,6 +254,8 @@
 		46569CD923CD0F0500224DC2 /* safari-popups-cosmetic.json in Resources */ = {isa = PBXBuildFile; fileRef = 46569CD723CD0F0500224DC2 /* safari-popups-cosmetic.json */; };
 		46569CDB23CD100E00224DC2 /* ContentBlocker+Popups+Whitelist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46569CDA23CD100E00224DC2 /* ContentBlocker+Popups+Whitelist.swift */; };
 		46569CDC23CD100E00224DC2 /* ContentBlocker+Popups+Whitelist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46569CDA23CD100E00224DC2 /* ContentBlocker+Popups+Whitelist.swift */; };
+		465E2AF823D1C66800ECEFA3 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465E2AF723D1C66800ECEFA3 /* Authenticator.swift */; };
+		465E2AF923D1C66800ECEFA3 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465E2AF723D1C66800ECEFA3 /* Authenticator.swift */; };
 		46828D7E233CF75000E7D8A3 /* BrowserViewController+InterceptorUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46828D7D233CF75000E7D8A3 /* BrowserViewController+InterceptorUI.swift */; };
 		46828D7F233CF75000E7D8A3 /* BrowserViewController+InterceptorUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46828D7D233CF75000E7D8A3 /* BrowserViewController+InterceptorUI.swift */; };
 		46828D81233D0A4900E7D8A3 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46828D80233D0A4900E7D8A3 /* MD5.swift */; };
@@ -1340,6 +1342,7 @@
 		46569CD423CCC60400224DC2 /* Whitelist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Whitelist.swift; sourceTree = "<group>"; };
 		46569CD723CD0F0500224DC2 /* safari-popups-cosmetic.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "safari-popups-cosmetic.json"; sourceTree = "<group>"; };
 		46569CDA23CD100E00224DC2 /* ContentBlocker+Popups+Whitelist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentBlocker+Popups+Whitelist.swift"; sourceTree = "<group>"; };
+		465E2AF723D1C66800ECEFA3 /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		467805F323154A160031E226 /* libSentry.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSentry.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		46828D7D233CF75000E7D8A3 /* BrowserViewController+InterceptorUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+InterceptorUI.swift"; sourceTree = "<group>"; };
 		46828D80233D0A4900E7D8A3 /* MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5.swift; sourceTree = "<group>"; };
@@ -2973,6 +2976,7 @@
 				63306D3821103EAE00F25400 /* SavedTab.swift */,
 				63306D422110B3CD00F25400 /* TabManagerStore.swift */,
 				39CE74FA21A8513B007AE4F2 /* TranslationService.swift */,
+				465E2AF723D1C66800ECEFA3 /* Authenticator.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -5055,6 +5059,7 @@
 				ACB7378323042BAB00FA5626 /* SearchSettingsTableViewController.swift in Sources */,
 				ACB7378423042BAB00FA5626 /* UserActivityHandler.swift in Sources */,
 				ACB7378523042BAB00FA5626 /* PhotonActionSheetAnimator.swift in Sources */,
+				465E2AF923D1C66800ECEFA3 /* Authenticator.swift in Sources */,
 				ACB7378623042BAB00FA5626 /* TabScrollController.swift in Sources */,
 				ACB7378823042BAB00FA5626 /* TranslationService.swift in Sources */,
 				ACB7378923042BAB00FA5626 /* UIViewExtensions.swift in Sources */,
@@ -5406,6 +5411,7 @@
 				46A4C4D6234775A800F4BCE0 /* AutoCompletion.m in Sources */,
 				46E7DD552361C53D00C8372A /* ReactViewTheme.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
+				465E2AF823D1C66800ECEFA3 /* Authenticator.swift in Sources */,
 				39CE74F021A6D2B8007AE4F2 /* DocumentServicesHelper.swift in Sources */,
 				2B4DFF2223CF0777001145AF /* BrowserSearch.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #665 

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->
As a sideeffect of removing Login Manager we've removed Authentication dialog for Simple HTTP auth. That was causing browser to crash in event of unhandled authentication challange. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
