### PR TITLE
Added New tab: Settings - Manage default segment #200

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -40,6 +40,7 @@ protocol HomeViewControllerProtocol: Themeable {
     func willMove(toParent parent: UIViewController?)
     func removeFromParent()
     func switchView(segment: HomeViewController.Segment)
+    func switchViewToDefaultSegment()
     func refresh()
 }
 
@@ -742,6 +743,8 @@ class BrowserViewController: UIViewController {
             view.addSubview(homeViewController.view)
             homeViewController.didMove(toParent: self)
         }
+
+        self.homeViewController?.switchViewToDefaultSegment()
 
         homeViewController?.applyTheme()
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -744,8 +744,6 @@ class BrowserViewController: UIViewController {
             homeViewController.didMove(toParent: self)
         }
 
-        self.homeViewController?.switchViewToDefaultSegment()
-
         homeViewController?.applyTheme()
 
         // We have to run this animation, even if the view is already showing
@@ -1720,6 +1718,9 @@ extension BrowserViewController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didRemoveTab tab: Tab, isRestoring: Bool) {
         if let url = tab.url, !(InternalURL(url)?.isAboutURL ?? false), !tab.isPrivate {
             profile.recentlyClosedTabs.addTab(url as URL, title: tab.title, faviconURL: tab.displayFavicon?.url)
+        }
+        if (tab.isPrivate && self.tabManager.privateTabs.isEmpty) || (!tab.isPrivate && self.tabManager.normalTabs.isEmpty) {
+            self.homeViewController?.switchViewToDefaultSegment()
         }
         updateTabCountUsingTabManager(tabManager)
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -413,7 +413,7 @@ class NewTabPageDefaultViewSetting: Setting {
 
     override var status: NSAttributedString {
         guard let segment = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView) else {
-            return NSAttributedString(string: HomeViewController.Segment.topSites.title)
+            return NSAttributedString(string: HomeViewController.Segment.defaultValue.title)
         }
         let title = HomeViewController.Segment(rawValue: segment)?.title ?? ""
         return NSAttributedString(string: title)
@@ -432,7 +432,7 @@ class NewTabPageDefaultViewSetting: Setting {
         if let segment = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView) {
             selectedSegment = HomeViewController.Segment(rawValue: segment)
         } else {
-            selectedSegment = .topSites
+            selectedSegment = HomeViewController.Segment.defaultValue
         }
         let availableSegments: [HomeViewController.Segment] = [.topSites, .bookmarks, .history]
         let viewController = NewTabDefaultViewSettingsViewController(profile: self.profile, selectedSegment: selectedSegment, availableSegments: availableSegments)

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -404,6 +404,42 @@ class OpenWithSetting: Setting {
     }
 }
 
+class NewTabPageDefaultViewSetting: Setting {
+    let profile: Profile
+
+    override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "DefaultView.Setting" }
+
+    override var status: NSAttributedString {
+        guard let segment = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView) else {
+            return NSAttributedString(string: HomeViewController.Segment.topSites.title)
+        }
+        let title = HomeViewController.Segment(rawValue: segment)?.title ?? ""
+        return NSAttributedString(string: title)
+    }
+
+    override var style: UITableViewCell.CellStyle { return .value1 }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+
+        super.init(title: NSAttributedString(string: Strings.Settings.NewTabPageDefaultView.SectionName, attributes: [NSAttributedString.Key.foregroundColor: Theme.tableView.rowText]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        var selectedSegment: HomeViewController.Segment!
+        if let segment = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView) {
+            selectedSegment = HomeViewController.Segment(rawValue: segment)
+        } else {
+            selectedSegment = .topSites
+        }
+        let availableSegments: [HomeViewController.Segment] = [.topSites, .bookmarks, .history]
+        let viewController = NewTabDefaultViewSettingsViewController(profile: self.profile, selectedSegment: selectedSegment, availableSegments: availableSegments)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 class TranslationSetting: Setting {
     let profile: Profile
     override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -100,6 +100,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
         let prefs = self.profile.prefs
         var generalSettings: [Setting] = [
             OpenWithSetting(settings: self),
+            NewTabPageDefaultViewSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
                         titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),
         ]

--- a/Client/Frontend/Settings/NewTabDefaulViewSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabDefaulViewSettingsViewController.swift
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import Shared
+
+class NewTabDefaultViewSettingsViewController: SettingsTableViewController {
+
+    private var selectedSegment: HomeViewController.Segment
+    private var availableSegments: [HomeViewController.Segment]
+
+    init(profile: Profile, selectedSegment: HomeViewController.Segment, availableSegments: [HomeViewController.Segment]) {
+        self.selectedSegment = selectedSegment
+        self.availableSegments = availableSegments
+        super.init(style: .grouped)
+        self.profile = profile
+        self.title = Strings.Settings.NewTabPageDefaultView.PageTitle
+        self.hasSectionSeparatorLine = false
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let searchSettings: [CheckmarkSetting] = self.availableSegments.map { segment in
+            return CheckmarkSetting(title: NSAttributedString(string: segment.title), subtitle: nil, accessibilityIdentifier: "\(segment.rawValue)", isEnabled: {
+                return segment.rawValue == self.selectedSegment.rawValue
+            }, onChanged: {
+                self.selectedSegment = segment
+                self.profile.prefs.setInt(segment.rawValue, forKey: PrefsKeys.NewTabPageDefaultView)
+                self.tableView.reloadData()
+                NotificationCenter.default.post(name: .NewTabPageDefaultViewSettingsDidChange, object: nil)
+            })
+        }
+        return [SettingSection(children: searchSettings)]
+    }
+
+}

--- a/Client/Frontend/Settings/NewTabDefaulViewSettingsViewController.swift
+++ b/Client/Frontend/Settings/NewTabDefaulViewSettingsViewController.swift
@@ -19,7 +19,7 @@ class NewTabDefaultViewSettingsViewController: SettingsTableViewController {
         self.availableSegments = availableSegments
         super.init(style: .grouped)
         self.profile = profile
-        self.title = Strings.Settings.NewTabPageDefaultView.PageTitle
+        self.title = Strings.Settings.NewTabPageDefaultView.SectionName
         self.hasSectionSeparatorLine = false
     }
 

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -177,8 +177,7 @@ extension Strings {
             public static let OpenURL = NSLocalizedString("Settings.Siri.OpenTabShortcut", comment: "The description of the open new tab siri shortcut")
         }
         public struct NewTabPageDefaultView {
-            public static let SectionName = NSLocalizedString("Settings.NewTabPageDefaultView.SectionName", comment: "The option in settings to configure default segment in Home when you open a new tab")
-            public static let PageTitle = NSLocalizedString("Settings.NewTabPageDefaultView.PageTitle", comment: "Title for new tab page default segment Settings")
+            public static let SectionName = NSLocalizedString("Settings.NewTabPageDefaultView.SectionName", comment: "The option in settings to configure default selected view in new tab")
         }
         public struct DNT {
             public static let NotTrackTitle = NSLocalizedString("Settings.DNT.Title", comment: "DNT Settings title")

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -176,6 +176,10 @@ extension Strings {
             public static let SectionDescription = String(format: NSLocalizedString("Settings.Siri.SectionDescription", comment: "The description that describes what siri shortcuts are"), AppInfo.displayName)
             public static let OpenURL = NSLocalizedString("Settings.Siri.OpenTabShortcut", comment: "The description of the open new tab siri shortcut")
         }
+        public struct NewTabPageDefaultView {
+            public static let SectionName = NSLocalizedString("Settings.NewTabPageDefaultView.SectionName", comment: "The option in settings to configure default segment in Home when you open a new tab")
+            public static let PageTitle = NSLocalizedString("Settings.NewTabPageDefaultView.PageTitle", comment: "Title for new tab page default segment Settings")
+        }
         public struct DNT {
             public static let NotTrackTitle = NSLocalizedString("Settings.DNT.Title", comment: "DNT Settings title")
             public static let OptionOnWithTP = NSLocalizedString("Settings.DNT.OptionOnWithTP", comment: "DNT Settings option for only turning on when Tracking Protection is also on")

--- a/Shared/NotificationConstants.swift
+++ b/Shared/NotificationConstants.swift
@@ -15,6 +15,9 @@ extension Notification.Name {
     // Fired when the user has changed news settings
     public static let NewsSettingsDidChange = Notification.Name("NewsSettingsDidChange")
 
+    // Fired when the user has changed new tab page default segment settings
+    public static let NewTabPageDefaultViewSettingsDidChange = Notification.Name("NewTabPageDefaultViewSettingsDidChange")
+
     // MARK: Notification UserInfo Keys
     public static let UserInfoKeyHasSyncableAccount = Notification.Name("UserInfoKeyHasSyncableAccount")
 

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -23,6 +23,7 @@ public struct PrefsKeys {
     public static let PrivacyDashboardEnabledKey = "prefkey.privacy.dashboard"
 
     public static let WhatsNewBubble = "WhatsNewBubble-\(AppInfo.appVersion)"
+    public static let NewTabPageDefaultView = "NewTabPageDefaultView"
 
     //News
     public static let NewTabNewsEnabled = "NewTabNewsEnabled"

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -839,6 +839,12 @@
 /* The option that takes you to the siri shortcuts settings page */
 "Settings.Siri.SectionName" = "Siri-Kürzel";
 
+/* The option in settings to configure default view in Home when you open a new tab */
+"Settings.NewTabPageDefaultView.SectionName" = "";
+
+/* Title for new tab page default view Settings */
+"Settings.NewTabPageDefaultView.PageTitle" = "";
+
 /* Explanation of basic mode. */
 "Settings.TrackingProtection.Info.BasicTitle" = "Ausgewogen für Schutz und Leistung.";
 

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -839,11 +839,8 @@
 /* The option that takes you to the siri shortcuts settings page */
 "Settings.Siri.SectionName" = "Siri-Kürzel";
 
-/* The option in settings to configure default view in Home when you open a new tab */
-"Settings.NewTabPageDefaultView.SectionName" = "";
-
-/* Title for new tab page default view Settings */
-"Settings.NewTabPageDefaultView.PageTitle" = "";
+/* The option in settings to configure default selected view in new tab */
+"Settings.NewTabPageDefaultView.SectionName" = "Neuer Tab";
 
 /* Explanation of basic mode. */
 "Settings.TrackingProtection.Info.BasicTitle" = "Ausgewogen für Schutz und Leistung.";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -842,11 +842,8 @@
 /* The option that takes you to the siri shortcuts settings page */
 "Settings.Siri.SectionName" = "Siri Shortcuts";
 
-/* The option in settings to configure default view in Home when you open a new tab */
-"Settings.NewTabPageDefaultView.SectionName" = "New Tab default view";
-
-/* Title for new tab page default view Settings */
-"Settings.NewTabPageDefaultView.PageTitle" = "Default view";
+/* The option in settings to configure default selected view in new tab */
+"Settings.NewTabPageDefaultView.SectionName" = "New Tab";
 
 /* Explanation of basic mode. */
 "Settings.TrackingProtection.Info.BasicTitle" = "Balanced for protection and performance.";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -842,6 +842,12 @@
 /* The option that takes you to the siri shortcuts settings page */
 "Settings.Siri.SectionName" = "Siri Shortcuts";
 
+/* The option in settings to configure default view in Home when you open a new tab */
+"Settings.NewTabPageDefaultView.SectionName" = "New Tab default view";
+
+/* Title for new tab page default view Settings */
+"Settings.NewTabPageDefaultView.PageTitle" = "Default view";
+
 /* Explanation of basic mode. */
 "Settings.TrackingProtection.Info.BasicTitle" = "Balanced for protection and performance.";
 

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		2B184F45BDED21008E6376E1 /* ClearHistoryConfirm.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BFF40A1903B290B5B168107 /* ClearHistoryConfirm.strings */; };
 		2B2EA06A235DE3DC00FCB9D3 /* ContentBlocker+Tracking+Whitelist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2EA069235DE3DC00FCB9D3 /* ContentBlocker+Tracking+Whitelist.swift */; };
 		2B2EA06B235F087100FCB9D3 /* ContentBlocker+Tracking+Whitelist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2EA069235DE3DC00FCB9D3 /* ContentBlocker+Tracking+Whitelist.swift */; };
+		2B427C7223D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B427C7123D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift */; };
+		2B427C7323D6E76500BF1308 /* NewTabDefaulViewSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B427C7123D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift */; };
 		2B473CED23952A2700442059 /* BloomFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CEC23952A2700442059 /* BloomFilter.swift */; };
 		2B473CEE23952A2700442059 /* BloomFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CEC23952A2700442059 /* BloomFilter.swift */; };
 		2B473CF1239637DE00442059 /* UseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B473CF0239637DE00442059 /* UseCases.swift */; };
@@ -1198,6 +1200,7 @@
 		29FDDD173651239132A7DE8D /* Pods-GhosteryShareTo.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GhosteryShareTo.adhoc.xcconfig"; path = "Target Support Files/Pods-GhosteryShareTo/Pods-GhosteryShareTo.adhoc.xcconfig"; sourceTree = "<group>"; };
 		2B03608F2350B07200273A24 /* tracker_db_v2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tracker_db_v2.json; sourceTree = "<group>"; };
 		2B2EA069235DE3DC00FCB9D3 /* ContentBlocker+Tracking+Whitelist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentBlocker+Tracking+Whitelist.swift"; sourceTree = "<group>"; };
+		2B427C7123D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabDefaulViewSettingsViewController.swift; sourceTree = "<group>"; };
 		2B473CEC23952A2700442059 /* BloomFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloomFilter.swift; sourceTree = "<group>"; };
 		2B473CF0239637DE00442059 /* UseCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCases.swift; sourceTree = "<group>"; };
 		2B473CF32396387B00442059 /* TabBarUseCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarUseCases.swift; sourceTree = "<group>"; };
@@ -2181,6 +2184,7 @@
 				C52F2D5623561BFA00146300 /* SearchSettingsTableViewCell.swift */,
 				2BD1D96E2358A6FB00B3362E /* SearchResultsSettingsViewController.swift */,
 				2B4EFBD723991AF3007A10E0 /* NewsLanguagesSettingsViewController.swift */,
+				2B427C7123D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -5123,6 +5127,7 @@
 				ACB737BF23042BAB00FA5626 /* SwipeAnimator.swift in Sources */,
 				ACB737C023042BAB00FA5626 /* SimpleToast.swift in Sources */,
 				46ECCD2423A3850D002E761C /* ContextMenu.m in Sources */,
+				2B427C7323D6E76500BF1308 /* NewTabDefaulViewSettingsViewController.swift in Sources */,
 				ACB737C123042BAB00FA5626 /* TrackingProtectionPageStats.swift in Sources */,
 				2B516D3A238BAC8B006D6B57 /* BookmarksView.swift in Sources */,
 				2B8DDBB323A3803E00D2CE7A /* PrivacyStatementCell.swift in Sources */,
@@ -5279,6 +5284,7 @@
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
 				46442CEA238BE148002E6D85 /* BrowserCore.swift in Sources */,
 				46BBFA672358B13A00283594 /* BrowserCliqz.m in Sources */,
+				2B427C7223D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift in Sources */,
 				04A788AB23980BC90085503F /* PrivacyIndicatorCanvasView.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,

--- a/UserAgent/Home View/HomeViewController.swift
+++ b/UserAgent/Home View/HomeViewController.swift
@@ -97,7 +97,7 @@ class HomeViewController: UIViewController {
             case .NewsSettingsDidChange:
                 self.refresh()
             case .NewTabPageDefaultViewSettingsDidChange:
-                self.selectDefaultSegment()
+                self.switchToDefaultSegment()
             default:
                 print("Error: Received unexpected notification \(notification.name)")
             }
@@ -116,7 +116,7 @@ private extension HomeViewController {
         setupConstraints()
     }
 
-    func selectDefaultSegment() {
+    func switchToDefaultSegment() {
         var defaultSegment: Segment = .topSites
         if let rawValue = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView), let segment = Segment(rawValue: rawValue) {
             defaultSegment = segment
@@ -127,7 +127,6 @@ private extension HomeViewController {
     }
 
     func setupSegmentedControl() {
-        self.selectDefaultSegment()
         segmentedControl.tintColor = UIColor.BrightBlue
     }
 
@@ -190,6 +189,10 @@ extension HomeViewController: HomeViewControllerProtocol {
     func switchView(segment: HomeViewController.Segment) {
         self.showView(segment: segment)
         self.segmentedControl.selectedSegmentIndex = self.segments.firstIndex(of: segment) ?? 0
+    }
+
+    func switchViewToDefaultSegment() {
+        self.switchToDefaultSegment()
     }
 
     func scrollToTop() {

--- a/UserAgent/Home View/HomeViewController.swift
+++ b/UserAgent/Home View/HomeViewController.swift
@@ -34,6 +34,10 @@ class HomeViewController: UIViewController {
             }
         }
 
+        static var defaultValue: Segment {
+            return .topSites
+        }
+
     }
 
     private let segments: [Segment] = [.topSites, .bookmarks, .history]
@@ -117,7 +121,7 @@ private extension HomeViewController {
     }
 
     func switchToDefaultSegment() {
-        var defaultSegment: Segment = .topSites
+        var defaultSegment: Segment = Segment.defaultValue
         if let rawValue = self.profile.prefs.intForKey(PrefsKeys.NewTabPageDefaultView), let segment = Segment(rawValue: rawValue) {
             defaultSegment = segment
         }
@@ -127,6 +131,7 @@ private extension HomeViewController {
     }
 
     func setupSegmentedControl() {
+        self.switchToDefaultSegment()
         segmentedControl.tintColor = UIColor.BrightBlue
     }
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #200 

## Implementation details
Added new tab settings to manage default segment in home page.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
