### PR TITLE
Fixed issue which make impossible to disable the first of Additional Search Engine. #702

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -49,7 +49,7 @@ class SearchEngines {
 
     var defaultEngine: OpenSearchEngine {
         get {
-            return self.orderedEngines[0]
+            return self.searchEnginesIncludedCliqz[0]
         }
 
         set(defaultEngine) {
@@ -85,7 +85,7 @@ class SearchEngines {
     }
 
     var quickSearchEngines: [OpenSearchEngine]! {
-        return self.orderedEngines.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
+        return self.searchEnginesIncludedCliqz.filter({ (engine) in !self.isEngineDefault(engine) && self.isEngineEnabled(engine) })
     }
 
     var shouldShowSearchSuggestions: Bool {

--- a/ClientTests/SearchEnginesTests.swift
+++ b/ClientTests/SearchEnginesTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import Shared
 
 private let DefaultSearchEngineName = "Cliqz"
-private let ExpectedEngineNames = ["Cliqz", "Google", "Bing", "DuckDuckGo"]
+private let ExpectedEngineNames = ["Cliqz", "Amazon.com", "Bing", "DuckDuckGo", "Google", "Twitter", "Wikipedia"]
 
 class SearchEnginesTests: XCTestCase {
 
@@ -74,7 +74,7 @@ class SearchEnginesTests: XCTestCase {
         let engines = SearchEngines(prefs: profile.prefs, files: profile.files)
 
         engines.orderedEngines = [ExpectedEngineNames[4], ExpectedEngineNames[2], ExpectedEngineNames[0]].map { name in
-            for engine in engines.orderedEngines {
+            for engine in engines.searchEnginesIncludedCliqz {
                 if engine.shortName == name {
                     return engine
                 }
@@ -90,12 +90,12 @@ class SearchEnginesTests: XCTestCase {
         // The ordering should have been persisted.
         XCTAssertEqual(engines2.orderedEngines[0].shortName, ExpectedEngineNames[4])
         XCTAssertEqual(engines2.orderedEngines[1].shortName, ExpectedEngineNames[2])
-        XCTAssertEqual(engines2.orderedEngines[2].shortName, ExpectedEngineNames[0])
+        XCTAssertEqual(engines2.orderedEngines[3].shortName, ExpectedEngineNames[3])
 
         // Remaining engines should be appended in alphabetical order.
-        XCTAssertEqual(engines2.orderedEngines[3].shortName, ExpectedEngineNames[1])
-        XCTAssertEqual(engines2.orderedEngines[4].shortName, ExpectedEngineNames[3])
-        XCTAssertEqual(engines2.orderedEngines[5].shortName, ExpectedEngineNames[5])
+        XCTAssertEqual(engines2.orderedEngines[3].shortName, ExpectedEngineNames[3])
+        XCTAssertEqual(engines2.orderedEngines[4].shortName, ExpectedEngineNames[5])
+        XCTAssertEqual(engines2.orderedEngines[5].shortName, ExpectedEngineNames[6])
     }
 
     func testQuickSearchEngines() {

--- a/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
+++ b/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
@@ -73,9 +73,6 @@
                   Identifier = "ProfileTest/testNewProfileClearsExistingAuthenticationInfo()">
                </Test>
                <Test
-                  Identifier = "SearchEnginesTests/testOrderedEngines()">
-               </Test>
-               <Test
                   Identifier = "SearchTests/testURIFixupPunyCode()">
                </Test>
                <Test


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #702 
Fix #701 

## Implementation details
Fixed issue according issue.
Enabled "cliqz.com" checkings in search engines tests
Disables some tests concerning default search engine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
