### PR TITLE
Disabled record privacy stats from private tabs #705

### DIFF
--- a/UserAgent/InsightsFeature.swift
+++ b/UserAgent/InsightsFeature.swift
@@ -23,6 +23,8 @@ extension InsightsFeature: TabManagerDelegate {
         if isRestoring { return }
         guard let stats = tab.contentBlocker?.stats else { return }
 
+        guard !tab.isPrivate else { return }
+
         self.reportStats(
             tabId: tab.id,
             trackers: stats.trackers,


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #705 

## Implementation details
Disabled record privacy stats for private tabs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [x] I updated or created necessary unit tests
- [x] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
