### PR TITLE
Fixed ussue when clearing browsing data does not clear privacy stats #700

### DIFF
--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -36,6 +36,7 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             (SiteDataClearable(tabManager: self.tabManager), true),
             (TrackingProtectionClearable(), true),
             (DownloadedFilesClearable(), false), // Don't clear downloaded files by default
+            (PrivacyStatsClearable(), false),
         ]
         return items
     }()

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -10,9 +10,6 @@ import CoreSpotlight
 
 private let log = Logger.browserLogger
 
-// Removed Clearables as part of Bug 1226654, but keeping the string around.
-private let removedSavedLoginsLabel = NSLocalizedString("Saved Logins", tableName: "ClearPrivateData", comment: "Settings item for clearing passwords and login data")
-
 // A base protocol for something that can be cleared.
 protocol Clearable {
     func clear() -> Success
@@ -36,7 +33,7 @@ class HistoryClearable: Clearable {
     }
 
     var label: String {
-        return NSLocalizedString("Browsing History", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history")
+        return Strings.Settings.DataManagement.PrivateData.BrowsingHistory
     }
 
     func clear() -> Success {
@@ -77,7 +74,7 @@ class CacheClearable: Clearable {
     }
 
     var label: String {
-        return NSLocalizedString("Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache")
+        return Strings.Settings.DataManagement.PrivateData.Cache
     }
 
     func clear() -> Success {
@@ -122,7 +119,7 @@ class SiteDataClearable: Clearable {
     }
 
     var label: String {
-        return NSLocalizedString("Offline Website Data", tableName: "ClearPrivateData", comment: "Settings item for clearing website data")
+        return Strings.Settings.DataManagement.PrivateData.OfflineWebsiteData
     }
 
     func clear() -> Success {
@@ -142,7 +139,7 @@ class CookiesClearable: Clearable {
     }
 
     var label: String {
-        return NSLocalizedString("Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies")
+        return Strings.Settings.DataManagement.PrivateData.Cookies
     }
 
     func clear() -> Success {
@@ -157,7 +154,7 @@ class CookiesClearable: Clearable {
 class TrackingProtectionClearable: Clearable {
     //TO DO: re-using string because we are too late in cycle to change strings
     var label: String {
-        return Strings.Settings.TrackingProtection.SectionName
+        return Strings.Settings.DataManagement.PrivateData.TrackingProtection
     }
 
     func clear() -> Success {
@@ -172,7 +169,7 @@ class TrackingProtectionClearable: Clearable {
 // Clears our downloaded files in the `~/Documents/Downloads` folder.
 class DownloadedFilesClearable: Clearable {
     var label: String {
-        return NSLocalizedString("Downloaded Files", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files")
+        return Strings.Settings.DataManagement.PrivateData.DownloadedFiles
     }
 
     func clear() -> Success {
@@ -186,5 +183,21 @@ class DownloadedFilesClearable: Clearable {
         NotificationCenter.default.post(name: .PrivateDataClearedDownloadedFiles, object: nil)
 
         return succeed()
+    }
+}
+
+// Clears privacy stats.
+class PrivacyStatsClearable: Clearable {
+    var label: String {
+        return Strings.Settings.DataManagement.PrivateData.PrivacyStats
+    }
+
+    func clear() -> Success {
+        let result = Success()
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            return result
+        }
+        appDelegate.insightsFeature.clearStats()
+        return result
     }
 }

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -89,7 +89,7 @@ extension PhotonActionSheetProtocol {
     func getBurnActions() -> [PhotonActionSheetItem] {
         let closeAllTabsAndClearData = PhotonActionSheetItem(title: Strings.Menu.CloseAllTabsAndClearDataTitleString, iconString: "menu-burn") { _ in
             self.tabManager.removeAllTabs()
-            let userData: [Clearable] = [HistoryClearable(profile: self.profile), CacheClearable(tabManager: self.tabManager), CookiesClearable(tabManager: self.tabManager), SiteDataClearable(tabManager: self.tabManager)]
+            let userData: [Clearable] = [HistoryClearable(profile: self.profile), CacheClearable(tabManager: self.tabManager), CookiesClearable(tabManager: self.tabManager), SiteDataClearable(tabManager: self.tabManager), PrivacyStatsClearable()]
             userData.forEach({ _ = $0.clear() })
         }
         return [closeAllTabsAndClearData]

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -127,6 +127,15 @@ extension Strings {
             public static let SectionName = NSLocalizedString("Settings.DataManagement.SectionName", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
             public static let SearchLabel = NSLocalizedString("Settings.DataManagement.SearchLabel", comment: "Default text in search bar for Data Management")
             public static let Title = NSLocalizedString("Settings.DataManagement.Title", comment: "Title displayed in header of the setting panel.")
+            public struct PrivateData {
+                public static let PrivacyStats = NSLocalizedString("Settings.DataManagement.PrivateData.PrivacyStats", tableName: "ClearPrivateData", comment: "Settings item for clearing privacy stats")
+                public static let TrackingProtection = NSLocalizedString("Settings.DataManagement.PrivateData.TrackingProtection", tableName: "ClearPrivateData", comment: "Settings item for clearing tracking protection")
+                public static let DownloadedFiles = NSLocalizedString("Settings.DataManagement.PrivateData.DownloadedFiles", tableName: "ClearPrivateData", comment: "Settings item for deleting downloaded files")
+                public static let Cookies = NSLocalizedString("Settings.DataManagement.PrivateData.Cookies", tableName: "ClearPrivateData", comment: "Settings item for clearing cookies")
+                public static let OfflineWebsiteData = NSLocalizedString("Settings.DataManagement.PrivateData.OfflineWebsiteData", tableName: "ClearPrivateData", comment: "Settings item for clearing website data")
+                public static let Cache = NSLocalizedString("Settings.DataManagement.PrivateData.Cache", tableName: "ClearPrivateData", comment: "Settings item for clearing the cache")
+                public static let BrowsingHistory = NSLocalizedString("Settings.DataManagement.PrivateData.BrowsingHistory", tableName: "ClearPrivateData", comment: "Settings item for clearing browsing history")
+            }
         }
         public struct WebsiteData {
             public static let Title = NSLocalizedString("Settings.WebsiteData.Title", comment: "Title displayed in header of the Data Management panel.")

--- a/Translations/de.lproj/ClearPrivateData.strings
+++ b/Translations/de.lproj/ClearPrivateData.strings
@@ -15,7 +15,7 @@
 "Settings.DataManagement.PrivateData.OfflineWebsiteData" = "Offline-Website-Daten";
 
 /* Settings item for clearing privacy stats */
-"Settings.DataManagement.PrivateData.PrivacyStats" = "";
+"Settings.DataManagement.PrivateData.PrivacyStats" = "Privatsphärenschutz Statistiken";
 
 /* Settings item for clearing tracking protection */
 "Settings.DataManagement.PrivateData.TrackingProtection" = "Schutz vor Aktivitätenverfolgung";

--- a/Translations/de.lproj/ClearPrivateData.strings
+++ b/Translations/de.lproj/ClearPrivateData.strings
@@ -1,18 +1,21 @@
 
 /* Settings item for clearing browsing history */
-"Browsing History" = "Besuchte Seiten";
+"Settings.DataManagement.PrivateData.BrowsingHistory" = "Besuchte Seiten";
 
 /* Settings item for clearing the cache */
-"Cache" = "Cache";
+"Settings.DataManagement.PrivateData.Cache" = "Cache";
 
 /* Settings item for clearing cookies */
-"Cookies" = "Cookies";
+"Settings.DataManagement.PrivateData.Cookies" = "Cookies";
 
 /* Settings item for deleting downloaded files */
-"Downloaded Files" = "Heruntergeladene Dateien";
+"Settings.DataManagement.PrivateData.DownloadedFiles" = "Heruntergeladene Dateien";
 
 /* Settings item for clearing website data */
-"Offline Website Data" = "Offline-Website-Daten";
+"Settings.DataManagement.PrivateData.OfflineWebsiteData" = "Offline-Website-Daten";
 
-/* Settings item for clearing passwords and login data */
-"Saved Logins" = "Gespeicherte Zugangsdaten";
+/* Settings item for clearing privacy stats */
+"Settings.DataManagement.PrivateData.PrivacyStats" = "";
+
+/* Settings item for clearing tracking protection */
+"Settings.DataManagement.PrivateData.TrackingProtection" = "Schutz vor Aktivitätenverfolgung";

--- a/Translations/en.lproj/ClearPrivateData.strings
+++ b/Translations/en.lproj/ClearPrivateData.strings
@@ -1,18 +1,21 @@
 
 /* Settings item for clearing browsing history */
-"Browsing History" = "Browsing History";
+"Settings.DataManagement.PrivateData.BrowsingHistory" = "Browsing History";
 
 /* Settings item for clearing the cache */
-"Cache" = "Cache";
+"Settings.DataManagement.PrivateData.Cache" = "Cache";
 
 /* Settings item for clearing cookies */
-"Cookies" = "Cookies";
+"Settings.DataManagement.PrivateData.Cookies" = "Cookies";
 
 /* Settings item for deleting downloaded files */
-"Downloaded Files" = "Downloaded Files";
+"Settings.DataManagement.PrivateData.DownloadedFiles" = "Downloaded Files";
 
 /* Settings item for clearing website data */
-"Offline Website Data" = "Offline Website Data";
+"Settings.DataManagement.PrivateData.OfflineWebsiteData" = "Offline Website Data";
 
-/* Settings item for clearing passwords and login data */
-"Saved Logins" = "Saved Logins";
+/* Settings item for clearing privacy stats */
+"Settings.DataManagement.PrivateData.PrivacyStats" = "Privacy stats";
+
+/* Settings item for clearing tracking protection */
+"Settings.DataManagement.PrivateData.TrackingProtection" = "Tracking Protection";

--- a/Translations/en.lproj/ClearPrivateData.strings
+++ b/Translations/en.lproj/ClearPrivateData.strings
@@ -15,7 +15,7 @@
 "Settings.DataManagement.PrivateData.OfflineWebsiteData" = "Offline Website Data";
 
 /* Settings item for clearing privacy stats */
-"Settings.DataManagement.PrivateData.PrivacyStats" = "Privacy stats";
+"Settings.DataManagement.PrivateData.PrivacyStats" = "Privacy Protection Stats";
 
 /* Settings item for clearing tracking protection */
 "Settings.DataManagement.PrivateData.TrackingProtection" = "Tracking Protection";

--- a/UserAgent/InsightsFeature.swift
+++ b/UserAgent/InsightsFeature.swift
@@ -16,6 +16,13 @@ class InsightsFeature: NSObject {
         self.tabManager = tabManager
         self.tabManager.addDelegate(self)
     }
+
+    func clearStats() {
+        self.browserCore.callAction(
+            module: "insights",
+            action: "clearData",
+            args: [])
+    }
 }
 
 extension InsightsFeature: TabManagerDelegate {


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #700 

## Implementation details
Added setting in data managment settings for clearing privacy stats data.
Updated clearables localizations.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
