### PR TITLE
Added settings: What should be opened when the App start: New Tab or Last opened Website #704

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -51,12 +51,39 @@ class WeakTabManagerDelegate {
 
 // TabManager must extend NSObjectProtocol in order to implement WKNavigationDelegate
 class TabManager: NSObject {
+
+    enum StartTab: Int32 {
+        case lastOpenedTab = 0
+        case newTab
+
+        var title: String {
+            switch self {
+            case .lastOpenedTab:
+                return Strings.Settings.OnBrowserStartTab.LastOpenedTab
+            case .newTab:
+                return Strings.Settings.OnBrowserStartTab.NewTab
+            }
+        }
+
+        static var defaultValue: StartTab {
+            return .lastOpenedTab
+        }
+
+    }
+
     fileprivate var delegates = [WeakTabManagerDelegate]()
     fileprivate let tabEventHandlers: [TabEventHandler]
     fileprivate let store: TabManagerStore
     fileprivate let profile: Profile
 
     let delaySelectingNewPopupTab: TimeInterval = 0.1
+
+    var startTab: StartTab {
+        guard let start = self.profile.prefs.intForKey(PrefsKeys.OnBrowserStartTab) else {
+            return StartTab.defaultValue
+        }
+        return StartTab(rawValue: start)!
+    }
 
     func addDelegate(_ delegate: TabManagerDelegate) {
         assert(Thread.isMainThread)

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -116,15 +116,17 @@ class TabManagerStore {
     }
 
     func restoreStartupTabs(clearPrivateTabs: Bool, tabManager: TabManager) -> Tab? {
-        var selectedTab = restoreTabs(savedTabs: archivedStartupTabs, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
+        var selectedTab = self.restoreTabs(savedTabs: archivedStartupTabs, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
         switch tabManager.startTab {
         case .lastOpenedTab: break
         case .newTab:
             if !(selectedTab?.isPureNewTabPage ?? false) {
-                selectedTab = tabManager.addTab()
+                self.lockedForReading = true
+                selectedTab = tabManager.tabs.first(where: { $0.isPureNewTabPage }) ?? tabManager.addTab()
+                self.lockedForReading = false
             }
         }
-        archivedStartupTabs.removeAll()
+        self.archivedStartupTabs.removeAll()
         return selectedTab
     }
 

--- a/Client/Frontend/Browser/TabManagerStore.swift
+++ b/Client/Frontend/Browser/TabManagerStore.swift
@@ -10,6 +10,7 @@ import XCGLogger
 
 private let log = Logger.browserLogger
 class TabManagerStore {
+
     fileprivate var lockedForReading = false
     fileprivate let imageStore: DiskImageStore?
     fileprivate var fileManager = FileManager.default
@@ -115,7 +116,14 @@ class TabManagerStore {
     }
 
     func restoreStartupTabs(clearPrivateTabs: Bool, tabManager: TabManager) -> Tab? {
-        let selectedTab = restoreTabs(savedTabs: archivedStartupTabs, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
+        var selectedTab = restoreTabs(savedTabs: archivedStartupTabs, clearPrivateTabs: clearPrivateTabs, tabManager: tabManager)
+        switch tabManager.startTab {
+        case .lastOpenedTab: break
+        case .newTab:
+            if !(selectedTab?.isPureNewTabPage ?? false) {
+                selectedTab = tabManager.addTab()
+            }
+        }
         archivedStartupTabs.removeAll()
         return selectedTab
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -441,7 +441,7 @@ class URLBarView: UIView {
 
     func updateProgressBar(_ progress: Float) {
         progressBar.alpha = 1
-        progressBar.isHidden = false
+        progressBar.isHidden = self.inOverlayMode
         progressBar.setProgress(progress, animated: !isTransitioning)
     }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -440,6 +440,42 @@ class NewTabPageDefaultViewSetting: Setting {
     }
 }
 
+class OnBrowserStartShowSetting: Setting {
+    let profile: Profile
+
+    override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "OnBrowserStartShow.Setting" }
+
+    override var status: NSAttributedString {
+        guard let segment = self.profile.prefs.intForKey(PrefsKeys.OnBrowserStartTab) else {
+            return NSAttributedString(string: TabManager.StartTab.defaultValue.title)
+        }
+        let title = TabManager.StartTab(rawValue: segment)?.title ?? ""
+        return NSAttributedString(string: title)
+    }
+
+    override var style: UITableViewCell.CellStyle { return .value1 }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+
+        super.init(title: NSAttributedString(string: Strings.Settings.OnBrowserStartTab.SectionName, attributes: [NSAttributedString.Key.foregroundColor: Theme.tableView.rowText]))
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        var selectedStartTab: TabManager.StartTab!
+        if let startTab = self.profile.prefs.intForKey(PrefsKeys.OnBrowserStartTab) {
+            selectedStartTab = TabManager.StartTab(rawValue: startTab)
+        } else {
+            selectedStartTab = TabManager.StartTab.defaultValue
+        }
+        let availableStartTabs: [TabManager.StartTab] = [.lastOpenedTab, .newTab]
+        let viewController = OnBrowserStartShowSettingsViewController(profile: self.profile, selectedStartTab: selectedStartTab, availableStartTabs: availableStartTabs)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 class TranslationSetting: Setting {
     let profile: Profile
     override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -101,6 +101,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
         var generalSettings: [Setting] = [
             OpenWithSetting(settings: self),
             NewTabPageDefaultViewSetting(settings: self),
+            OnBrowserStartShowSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
                         titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),
         ]

--- a/Client/Frontend/Settings/OnBrowserStartShowSettingsViewController.swift
+++ b/Client/Frontend/Settings/OnBrowserStartShowSettingsViewController.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import Shared
+
+class OnBrowserStartShowSettingsViewController: SettingsTableViewController {
+
+    private var selectedStartTab: TabManager.StartTab
+    private var availableStartTabs: [TabManager.StartTab]
+
+    init(profile: Profile, selectedStartTab: TabManager.StartTab, availableStartTabs: [TabManager.StartTab]) {
+        self.selectedStartTab = selectedStartTab
+        self.availableStartTabs = availableStartTabs
+        super.init(style: .grouped)
+        self.profile = profile
+        self.title = Strings.Settings.OnBrowserStartTab.SectionName
+        self.hasSectionSeparatorLine = false
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let searchSettings: [CheckmarkSetting] = self.availableStartTabs.map { startTab in
+            return CheckmarkSetting(title: NSAttributedString(string: startTab.title), subtitle: nil, accessibilityIdentifier: "\(startTab.rawValue)", isEnabled: {
+                return startTab.rawValue == self.selectedStartTab.rawValue
+            }, onChanged: {
+                self.selectedStartTab = startTab
+                self.profile.prefs.setInt(startTab.rawValue, forKey: PrefsKeys.OnBrowserStartTab)
+                self.tableView.reloadData()
+            })
+        }
+        return [SettingSection(children: searchSettings)]
+    }
+
+}

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -169,6 +169,11 @@ extension Strings {
         public struct NewTab {
             public static let TopSites = String(format: NSLocalizedString("Settings.NewTab.Option.Home", comment: "Option in settings to show Firefox Home when you open a new tab"), AppInfo.displayName)
         }
+        public struct OnBrowserStartTab {
+            public static let SectionName = NSLocalizedString("Settings.OnBrowserStartTab.SectionName", comment: "The option in settings to configure first launch tab")
+            public static let LastOpenedTab = NSLocalizedString("Settings.OnBrowserStartTab.LastOpenedTab", comment: "The option in settings to configure first launch to open last opened tab")
+            public static let NewTab = NSLocalizedString("Settings.OnBrowserStartTab.NewTab", comment: "The option in settings to configure first launch to open new tab")
+        }
         public struct OpenWith {
             public static let SectionName = NSLocalizedString("Settings.OpenWith.SectionName", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the open with (mail links) behaviour.")
             public static let PageTitle = NSLocalizedString("Settings.OpenWith.PageTitle", comment: "Title for Open With Settings")

--- a/Shared/Prefs.swift
+++ b/Shared/Prefs.swift
@@ -24,6 +24,7 @@ public struct PrefsKeys {
 
     public static let WhatsNewBubble = "WhatsNewBubble-\(AppInfo.appVersion)"
     public static let NewTabPageDefaultView = "NewTabPageDefaultView"
+    public static let OnBrowserStartTab = "OnBrowserStartTab"
 
     //News
     public static let NewTabNewsEnabled = "NewTabNewsEnabled"

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -793,6 +793,15 @@
 /* Option in settings to show UserAgent Home when you open a new tab */
 "Settings.NewTab.Option.Home" = "%@ Home";
 
+/* The option in settings to configure first launch tab */
+"Settings.OnBrowserStartTab.SectionName" = "";
+
+/* The option in settings to configure first launch to open last opened tab */
+"Settings.OnBrowserStartTab.LastOpenedTab" = "";
+
+/* The option in settings to configure first launch to open new tab */
+"Settings.OnBrowserStartTab.NewTab" = "";
+
 /* Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349 */
 "Settings.OfferClipboardBar.Status" = "Wenn %@ geöffnet wird";
 

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -794,13 +794,13 @@
 "Settings.NewTab.Option.Home" = "%@ Home";
 
 /* The option in settings to configure first launch tab */
-"Settings.OnBrowserStartTab.SectionName" = "";
+"Settings.OnBrowserStartTab.SectionName" = "Beim Browserstart anzeigen";
 
 /* The option in settings to configure first launch to open last opened tab */
-"Settings.OnBrowserStartTab.LastOpenedTab" = "";
+"Settings.OnBrowserStartTab.LastOpenedTab" = "Zuletzt geöffneter Tab";
 
 /* The option in settings to configure first launch to open new tab */
-"Settings.OnBrowserStartTab.NewTab" = "";
+"Settings.OnBrowserStartTab.NewTab" = "Newtab-Seite";
 
 /* Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349 */
 "Settings.OfferClipboardBar.Status" = "Wenn %@ geöffnet wird";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -796,6 +796,15 @@
 /* Option in settings to show UserAgent Home when you open a new tab */
 "Settings.NewTab.Option.Home" = "%@ Home";
 
+/* The option in settings to configure first launch tab */
+"Settings.OnBrowserStartTab.SectionName" = "On Browser start show";
+
+/* The option in settings to configure first launch to open last opened tab */
+"Settings.OnBrowserStartTab.LastOpenedTab" = "Last opened Tab";
+
+/* The option in settings to configure first launch to open new tab */
+"Settings.OnBrowserStartTab.NewTab" = "New Tab Page";
+
 /* Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349 */
 "Settings.OfferClipboardBar.Status" = "When Opening %@";
 

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		2BE2591A23BA314D0022ED28 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		2BE2591B23BA314E0022ED28 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		2BE9C93123E169450074E55E /* OnBrowserStartShowSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE9C93023E169450074E55E /* OnBrowserStartShowSettingsViewController.swift */; };
+		2BE9C93223E1C5B60074E55E /* OnBrowserStartShowSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE9C93023E169450074E55E /* OnBrowserStartShowSettingsViewController.swift */; };
 		2BFB7C36238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C35238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift */; };
 		2BFB7C37238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C35238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift */; };
 		2BFB7C39238FB06300CE2E69 /* AutomaticForgetModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C38238FB06300CE2E69 /* AutomaticForgetModeDetector.swift */; };
@@ -5160,6 +5161,7 @@
 				ACB737D323042BAB00FA5626 /* ReadabilityService.swift in Sources */,
 				ACB737D423042BAB00FA5626 /* main.swift in Sources */,
 				ACB737D523042BAB00FA5626 /* WebPagesForTesting.swift in Sources */,
+				2BE9C93223E1C5B60074E55E /* OnBrowserStartShowSettingsViewController.swift in Sources */,
 				ACB737D623042BAB00FA5626 /* BrowserViewController.swift in Sources */,
 				46CA60E32316D4A80010CE6B /* History.swift in Sources */,
 				04A788AE239A545D0085503F /* PrivacyIndicatorUtils.swift in Sources */,

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		2BE2591923BA31420022ED28 /* NSUserDefaultsPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD19A661A25309B0084FBA7 /* NSUserDefaultsPrefs.swift */; };
 		2BE2591A23BA314D0022ED28 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		2BE2591B23BA314E0022ED28 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
+		2BE9C93123E169450074E55E /* OnBrowserStartShowSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE9C93023E169450074E55E /* OnBrowserStartShowSettingsViewController.swift */; };
 		2BFB7C36238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C35238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift */; };
 		2BFB7C37238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C35238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift */; };
 		2BFB7C39238FB06300CE2E69 /* AutomaticForgetModeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFB7C38238FB06300CE2E69 /* AutomaticForgetModeDetector.swift */; };
@@ -1241,6 +1242,7 @@
 		2BE258E923BA2B5B0022ED28 /* GhosteryOpenIn.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GhosteryOpenIn.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		2BE2590F23BA2FD40022ED28 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2BE2591123BA2FD60022ED28 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2BE9C93023E169450074E55E /* OnBrowserStartShowSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBrowserStartShowSettingsViewController.swift; sourceTree = "<group>"; };
 		2BFB7C35238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticForgetModePolicy.swift; sourceTree = "<group>"; };
 		2BFB7C38238FB06300CE2E69 /* AutomaticForgetModeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticForgetModeDetector.swift; sourceTree = "<group>"; };
 		2BFB7C3E239001CB00CE2E69 /* adult-domains.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = "adult-domains.bin"; sourceTree = "<group>"; };
@@ -2185,6 +2187,7 @@
 				2BD1D96E2358A6FB00B3362E /* SearchResultsSettingsViewController.swift */,
 				2B4EFBD723991AF3007A10E0 /* NewsLanguagesSettingsViewController.swift */,
 				2B427C7123D6E76200BF1308 /* NewTabDefaulViewSettingsViewController.swift */,
+				2BE9C93023E169450074E55E /* OnBrowserStartShowSettingsViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -5354,6 +5357,7 @@
 				46828D89233E213A00E7D8A3 /* PrivacyIndicatorView.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
 				C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */,
+				2BE9C93123E169450074E55E /* OnBrowserStartShowSettingsViewController.swift in Sources */,
 				C56ED4A7233B95BF006A63B1 /* AntiPhishingDetector.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				A83E5AB71C1D993D0026D912 /* UIPasteboardExtensions.swift in Sources */,


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #704 

## Implementation details
Added on browser start setting to configuring launch first tab.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
