### PR TITLE
Open Links from library does not work if triggered from new tab page in overlay mode. #681

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -882,9 +882,12 @@ class BrowserViewController: UIViewController {
 
     func openURLInNewTab(url: URL, isPrivate: Bool) {
         let tab = self.tabManager.addTab(PrivilegedRequest(url: url) as URLRequest, afterTab: self.tabManager.selectedTab, isPrivate: isPrivate)
+        if self.urlBar.inOverlayMode {
+            self.urlBar.cancel()
+        }
         // If we are showing toptabs a user can just use the top tab bar
         // If in overlay mode switching doesnt correctly dismiss the homepanels
-        guard !topTabsVisible, !self.urlBar.inOverlayMode else {
+        guard !topTabsVisible else {
             return
         }
         // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -885,18 +885,8 @@ class BrowserViewController: UIViewController {
         if self.urlBar.inOverlayMode {
             self.urlBar.cancel()
         }
-        // If we are showing toptabs a user can just use the top tab bar
-        // If in overlay mode switching doesnt correctly dismiss the homepanels
-        guard !topTabsVisible else {
-            return
-        }
-        // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-        let toast = ButtonToast(labelText: Strings.ContextMenu.ButtonToast.NewTabOpened.LabelText, buttonText: Strings.ContextMenu.ButtonToast.NewTabOpened.ButtonText, completion: { buttonPressed in
-            if buttonPressed {
-                self.tabManager.selectTab(tab)
-            }
-        })
-        self.show(toast: toast)
+
+        self.tabManager.selectTab(tab)
     }
 
     func openAndShowURLInNewTab(url: URL, isPrivate: Bool) {
@@ -1872,17 +1862,9 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             screenshotHelper.takeDelayedScreenshot(currentTab)
 
             let addTab = { (rURL: URL, isPrivate: Bool) in
-                    let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
-                    guard !self.topTabsVisible else {
-                        return
-                    }
-                    // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                let toast = ButtonToast(labelText: Strings.ContextMenu.ButtonToast.NewTabOpened.LabelText, buttonText: Strings.ContextMenu.ButtonToast.NewTabOpened.ButtonText, completion: { buttonPressed in
-                        if buttonPressed {
-                            self.tabManager.selectTab(tab)
-                        }
-                    })
-                    self.show(toast: toast)
+                let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
+
+                self.tabManager.selectTab(tab)
             }
 
             if !isPrivate {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -120,23 +120,8 @@ extension BrowserViewController: WKUIDelegate {
             let isPrivate = currentTab.isPrivate
             let addTab = { (rURL: URL, isPrivate: Bool) in
                 let tab = self.tabManager.addTab(URLRequest(url: rURL as URL), afterTab: currentTab, isPrivate: isPrivate)
-                guard !self.topTabsVisible else {
-                    return
-                }
-                var toastLabelText: String
 
-                if isPrivate {
-                    toastLabelText = Strings.ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText
-                } else {
-                    toastLabelText = Strings.ContextMenu.ButtonToast.NewTabOpened.LabelText
-                }
-                // We're not showing the top tabs; show a toast to quick switch to the fresh new tab.
-                let toast = ButtonToast(labelText: toastLabelText, buttonText: Strings.ContextMenu.ButtonToast.NewTabOpened.ButtonText, completion: { buttonPressed in
-                    if buttonPressed {
-                        self.tabManager.selectTab(tab)
-                    }
-                })
-                self.show(toast: toast)
+                self.tabManager.selectTab(tab)
             }
 
             let getImageData = { (_ url: URL, success: @escaping (Data) -> Void) in

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -434,6 +434,10 @@ class URLBarView: UIView {
         updateViewsForOverlayModeAndToolbarChanges()
     }
 
+    func cancel() {
+        self.didClickCancel()
+    }
+
     func updateAlphaForSubviews(_ alpha: CGFloat) {
         locationContainer.alpha = alpha
         self.alpha = alpha

--- a/Shared/Localization/Strings.swift
+++ b/Shared/Localization/Strings.swift
@@ -347,10 +347,6 @@ extension Strings {
                 public static let LabelText = NSLocalizedString("ContextMenu.ButtonToast.NewTabOpened.LabelText", comment: "The label text in the Button Toast for switching to a fresh New Tab.")
                 public static let ButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewTabOpened.ButtonText", comment: "The button text in the Button Toast for switching to a fresh New Tab.")
             }
-            public struct NewPrivateTabOpened {
-                public static let LabelText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText", comment: "The label text in the Button Toast for switching to a fresh New Private Tab.")
-                public static let ButtonText = NSLocalizedString("ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText", comment: "The button text in the Button Toast for switching to a fresh New Private Tab.")
-            }
         }
         public static let OpenInNewTab = NSLocalizedString("ContextMenu.OpenInNewTabButtonTitle", comment: "Context menu item for opening a link in a new tab")
         public static let BookmarkLink = NSLocalizedString("ContextMenu.BookmarkLinkButtonTitle", comment: "Context menu item for bookmarking a link URL")

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -117,12 +117,6 @@
 /* Context menu item for bookmarking a link URL */
 "ContextMenu.BookmarkLinkButtonTitle" = "Lesezeichen für Link setzen";
 
-/* The button text in the Button Toast for switching to a fresh New Private Tab. */
-"ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText" = "Umschalten";
-
-/* The label text in the Button Toast for switching to a fresh New Private Tab. */
-"ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText" = "Neuer privater Tab geöffnet";
-
 /* The button text in the Button Toast for switching to a fresh New Tab. */
 "ContextMenu.ButtonToast.NewTabOpened.ButtonText" = "Umschalten";
 

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -117,12 +117,6 @@
 /* Context menu item for bookmarking a link URL */
 "ContextMenu.BookmarkLinkButtonTitle" = "Bookmark Link";
 
-/* The button text in the Button Toast for switching to a fresh New Private Tab. */
-"ContextMenu.ButtonToast.NewPrivateTabOpened.ButtonText" = "Switch";
-
-/* The label text in the Button Toast for switching to a fresh New Private Tab. */
-"ContextMenu.ButtonToast.NewPrivateTabOpened.LabelText" = "New Private Tab opened";
-
 /* The button text in the Button Toast for switching to a fresh New Tab. */
 "ContextMenu.ButtonToast.NewTabOpened.ButtonText" = "Switch";
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #681 

## Implementation details
Fixed open in new tab action issue from when overlay is active.
Remvoed "Switch" toast. Now new tab is opening immediately.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
