### PR TITLE
Crypto APIs for React Native

### DIFF
--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(WindowCrypto, NSObject)
+
+RCT_EXTERN_METHOD(digest:(NSString)algorithm data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -11,5 +11,6 @@
 @interface RCT_EXTERN_MODULE(WindowCrypto, NSObject)
 
 RCT_EXTERN_METHOD(digest:(NSString)algorithm data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(generateEntropy:(NSInteger)count resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -17,5 +17,6 @@ RCT_EXTERN_METHOD(exportKey:(NSInteger)id resolve:(RCTPromiseResolveBlock)resolv
 RCT_EXTERN_METHOD(importKey:(NSString)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(deriveKey:(NSString)privateKey publicKey:(NSString)publicKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(encrypt:(NSInteger)keyId iv:(NSString)iv data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(decrypt:(NSInteger)keyId iv:(NSString)iv tag:(NSString)tag data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -14,5 +14,6 @@ RCT_EXTERN_METHOD(digest:(NSString)algorithm data:(NSString)data resolve:(RCTPro
 RCT_EXTERN_METHOD(generateEntropy:(NSInteger)count resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(generateKey:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(exportKey:(NSInteger)id resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(importKey:(NSString)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -16,5 +16,6 @@ RCT_EXTERN_METHOD(generateKey:(RCTPromiseResolveBlock)resolve reject:(RCTPromise
 RCT_EXTERN_METHOD(exportKey:(NSInteger)id resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(importKey:(NSString)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(deriveKey:(NSString)privateKey publicKey:(NSString)publicKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(encrypt:(NSInteger)keyId iv:(NSString)iv data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -12,5 +12,6 @@
 
 RCT_EXTERN_METHOD(digest:(NSString)algorithm data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(generateEntropy:(NSInteger)count resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(generateKey:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -13,5 +13,6 @@
 RCT_EXTERN_METHOD(digest:(NSString)algorithm data:(NSString)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(generateEntropy:(NSInteger)count resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(generateKey:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(exportKey:(NSInteger)id resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCrypto.m
+++ b/ReactNative/WindowAPI/WindowCrypto.m
@@ -15,5 +15,6 @@ RCT_EXTERN_METHOD(generateEntropy:(NSInteger)count resolve:(RCTPromiseResolveBlo
 RCT_EXTERN_METHOD(generateKey:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(exportKey:(NSInteger)id resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(importKey:(NSString)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(deriveKey:(NSString)privateKey publicKey:(NSString)publicKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ReactNative/WindowAPI/WindowCryto.swift
+++ b/ReactNative/WindowAPI/WindowCryto.swift
@@ -46,8 +46,32 @@ extension Data {
     }
 }
 
+class WindowCryptoBase: NSObject {
+    @objc(requiresMainQueueSetup)
+    static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+}
+
 @objc(WindowCrypto)
-class WindowCrypto: NSObject {
+class WindowCrypto: WindowCryptoBase {
+    @objc(digest:data:resolve:reject:)
+    public func digest(
+        algorighm: NSString,
+        data: NSString,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject("E_crypto", "Crypto operations are not support for iOS older than 13", nil)
+    }
+}
+
+@available(iOS 13.0, *)
+@objc(WindowCrypto)
+class WindowCrypto13: WindowCryptoBase {
+    private var privateKeys: [P256.KeyAgreement.PrivateKey] = []
+    private var publicKeys: [P256.KeyAgreement.PrivateKey] = []
+
     @objc(digest:data:resolve:reject:)
     public func digest(
         algorighm: NSString,
@@ -56,18 +80,13 @@ class WindowCrypto: NSObject {
         reject: @escaping RCTPromiseRejectBlock
     ) {
         if algorighm == "SHA-256" {
-            if #available(iOS 13.0, *) {
-                guard let data = Data(hexString: data as String) else {
-                    reject("E_data", "Data in wrong format", nil)
-                    return
-                }
-                let hash = SHA256.hash(data: data)
-                let hexHash = hash.compactMap { String(format: "%02x", $0) }.joined()
-                resolve(hexHash)
-            } else {
-                reject("E_crypto", "Crypto operations are not support for iOS older than 13", nil)
+            guard let data = Data(hexString: data as String) else {
+                reject("E_data", "Data in wrong format", nil)
                 return
             }
+            let hash = SHA256.hash(data: data)
+            let hexHash = hash.compactMap { String(format: "%02x", $0) }.joined()
+            resolve(hexHash)
         } else {
             reject("E_algorithm", "Algorithm is not supported", nil)
         }
@@ -83,8 +102,11 @@ class WindowCrypto: NSObject {
         resolve(random.toHexString())
     }
 
-    @objc(requiresMainQueueSetup)
-    static func requiresMainQueueSetup() -> Bool {
-        return false
+    @objc(generateKey:reject:)
+    public func generateKey(
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        reject("E_crypto", "Crypto operations are not support for iOS older than 13", nil)
     }
 }

--- a/ReactNative/WindowAPI/WindowCryto.swift
+++ b/ReactNative/WindowAPI/WindowCryto.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+import Foundation
+import React
+import CryptoKit
+
+extension Data {
+    init?(hexString: String) {
+        let length = hexString.count / 2
+        var data = Data(capacity: length)
+        for i in 0 ..< length {
+            let j = hexString.index(hexString.startIndex, offsetBy: i * 2)
+            let k = hexString.index(j, offsetBy: 2)
+            let bytes = hexString[j..<k]
+            if var byte = UInt8(bytes, radix: 16) {
+                data.append(&byte, count: 1)
+            } else {
+                return nil
+            }
+        }
+        self = data
+    }
+}
+
+@objc(WindowCrypto)
+class WindowCrypto: NSObject {
+    @objc(digest:data:resolve:reject:)
+    public func digest(
+        algorighm: NSString,
+        data: NSString,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        if algorighm == "SHA-256" {
+            if #available(iOS 13.0, *) {
+                guard let data = Data(hexString: data as String) else {
+                    reject("E_data", "Data in wrong format", nil)
+                    return
+                }
+                let hash = SHA256.hash(data: data)
+                let hashString = hash.compactMap { String(format: "%02x", $0) }.joined()
+                resolve(hashString)
+            } else {
+                reject("E_crypto", "Crypto operations are not support for iOS older than 13", nil)
+                return
+            }
+        } else {
+            reject("E_algorithm", "Algorithm is not supported", nil)
+        }
+    }
+
+    @objc(requiresMainQueueSetup)
+    static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+}

--- a/ReactNative/WindowAPI/WindowCryto.swift
+++ b/ReactNative/WindowAPI/WindowCryto.swift
@@ -240,7 +240,7 @@ class WindowCrypto: NSObject {
         do {
             let nonce = try AES.GCM.Nonce(data: iv)
             let box = try AES.GCM.seal(message, using: symmetricKey, nonce: nonce)
-            resolve(box.ciphertext.toHexString())
+            resolve(box.ciphertext.toHexString() + box.tag.toHexString())
         } catch {
             reject("E_data", "Data in wrong format", nil)
             return
@@ -284,7 +284,13 @@ class WindowCrypto: NSObject {
         let symmetricKey = SymmetricKey(data: sharedSecret)
         do {
             let nonce = try AES.GCM.Nonce(data: iv)
-            let box = try AES.GCM.SealedBox(nonce: nonce, ciphertext: cipher, tag: tag)
+            let box: AES.GCM.SealedBox
+            do {
+                box = try AES.GCM.SealedBox(nonce: nonce, ciphertext: cipher, tag: tag)
+            } catch {
+                reject("E_data", "Data in wrong format", nil)
+                return
+            }
             let decryptedData = try AES.GCM.open(box, using: symmetricKey)
             resolve(decryptedData.toHexString())
         } catch {

--- a/ReactNative/WindowAPI/WindowCryto.swift
+++ b/ReactNative/WindowAPI/WindowCryto.swift
@@ -299,6 +299,17 @@ class WindowCrypto: NSObject {
         }
     }
 
+    @objc
+    func constantsToExport() -> [String: Any]! {
+        var isAvailable = false
+        if #available(iOS 13.0, *) {
+            isAvailable = true
+        }
+        return [
+            "isAvailable": isAvailable,
+        ]
+    }
+
     @objc(requiresMainQueueSetup)
     static func requiresMainQueueSetup() -> Bool {
         return false

--- a/ReactNative/js/globals/navigator/userAgent.js
+++ b/ReactNative/js/globals/navigator/userAgent.js
@@ -3,7 +3,11 @@ import { NativeModules } from 'react-native';
 const { userAgent } = NativeModules.Constants;
 
 // TODO: investigate who is using it
-global.navigator.userAgent = userAgent;
+try {
+  global.navigator.userAgent = userAgent;
+} catch (e) {
+  // breaks debugging in Chrome
+}
 
 // eslint-disable-next-line no-underscore-dangle
 const _fetch = global.window.fetch;

--- a/ReactNative/js/globals/window/DOMParser.js
+++ b/ReactNative/js/globals/window/DOMParser.js
@@ -1,10 +1,9 @@
+/* eslint-disable import/prefer-default-export */
 import jsdom from 'jsdom-jscore-rn';
 
-class DOMParser {
+export class DOMParser {
   // eslint-disable-next-line class-methods-use-this
   parseFromString(text /* , format */) {
     return jsdom.html(text);
   }
 }
-
-window.DOMParser = DOMParser;

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -1,13 +1,12 @@
-/* eslint-disable import/prefer-default-export */
 import { NativeModules } from 'react-native';
 
-function toHexString(buffer: ArrayBuffer) {
+function arrayBufferToHexString(buffer: ArrayBuffer) {
   return Array.prototype.map
     .call(new Uint8Array(buffer), x => `00${x.toString(16)}`.slice(-2))
     .join('');
 }
 
-function toByteArray(hexString: string): ArrayBuffer {
+function hexStringToByteArray(hexString: string): ArrayBuffer {
   const typedArray = new Uint8Array(
     (hexString.match(/[\da-f]{2}/gi) || []).map((h: string) => {
       return parseInt(h, 16);
@@ -16,7 +15,69 @@ function toByteArray(hexString: string): ArrayBuffer {
   return typedArray.buffer;
 }
 
+function toByteArray(data: any) {
+  if (data.buffer) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return new Uint8Array(data);
+}
+
+class RandomPool {
+  pool: number[] = [];
+
+  pending: number = 0;
+
+  addEntropy(entropy: ArrayBuffer) {
+    const buffer = new Uint8Array(entropy);
+    Array.prototype.forEach.call(buffer, x => {
+      this.pool.push(x);
+    });
+    this.pending -= buffer.length;
+    if (this.pending < 0) {
+      throw new Error('Something went wrong');
+    }
+  }
+
+  getRandomByte(): number {
+    const randomByte = this.pool.shift();
+    if (this.pool.length + this.pending < 1024 * 48) {
+      this.fetchEntropy(1024 * 64);
+    }
+
+    if (typeof randomByte === 'undefined') {
+      throw new Error("We've run out of entropy, sorry.");
+    }
+
+    return randomByte;
+  }
+
+  async fetchEntropy(size: number) {
+    this.pending += size;
+    const randomString = await NativeModules.WindowCrypto.generateEntropy(size);
+    const randomBuffer = hexStringToByteArray(randomString);
+    this.addEntropy(randomBuffer);
+  }
+}
+
+const randomPool = new RandomPool();
+
+type TypedArray = ArrayBuffer | Uint8Array | Uint16Array | Uint32Array;
 export const crypto = {
+  getRandomValues(a: TypedArray) {
+    const view = toByteArray(a);
+    const len = view.length;
+
+    if (len > 65536) {
+      throw new Error('crypto.getRandomValues: Quota exceeded');
+    }
+
+    // const rnd = forge.random.getBytesSync(len);
+    for (let i = 0; i < len; i += 1) {
+      const x = randomPool.getRandomByte();
+      view[i] = x;
+    }
+    return a;
+  },
   subtle: {
     async digest(
       algorithm: string | { name: string },
@@ -24,13 +85,17 @@ export const crypto = {
     ): Promise<ArrayBuffer> {
       const algorithmName =
         typeof algorithm === 'string' ? algorithm : algorithm.name;
-      const serializedData = toHexString(data);
+      const serializedData = arrayBufferToHexString(data);
 
       const hexHash = await NativeModules.WindowCrypto.digest(
         algorithmName,
         serializedData,
       );
-      return toByteArray(hexHash);
+      return hexStringToByteArray(hexHash);
     },
   },
+};
+
+export const seedRandom = async () => {
+  return randomPool.fetchEntropy(1024 * 64);
 };

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -212,8 +212,8 @@ export const crypto = {
         throw new Error('No iv');
       }
       const hexString = arrayBufferToHexString(data.buffer);
-      const dataHexString = hexString.slice(0, -8);
-      const tagHexString = hexString.slice(-8);
+      const dataHexString = hexString.slice(0, -32);
+      const tagHexString = hexString.slice(-32);
       const ivHexString = arrayBufferToHexString(algorithm.iv);
       const encryptedDataHexString = await NativeModules.WindowCrypto.decrypt(
         key.id,
@@ -264,8 +264,6 @@ export const crypto = {
 
   // testing import and export
   {
-    console.warn('Bob public original', bobPublicArray);
-
     const bobPublicCopy = await crypto.subtle.importKey(
       'raw',
       bobPublicArray,
@@ -278,7 +276,6 @@ export const crypto = {
       bobPublicCopy,
     );
     const bobPublicCopyArray = new Uint8Array(bobPublicCopyRaw);
-    console.warn('Bob public imported', bobPublicCopyArray);
   }
 
   const aliceDerivedKey = await crypto.subtle.deriveKey(

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -225,6 +225,9 @@ export const crypto = {
       if (!algorithm.iv) {
         throw new Error('No iv');
       }
+      // crypto.subtle represents the results of AES-GCM-128 as one array, while cryptokit expects
+      // ciphertext and tag to come as separate arguments. crypto.subtle will put the tag at the end,
+      // so we can split it of. The tag is 128 bits long, which is 16 bytes, or 32 bytes in hex-representation.
       const hexString = toHexString(data);
       const dataHexString = hexString.slice(0, -32);
       const tagHexString = hexString.slice(-32);

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -183,6 +183,10 @@ export const crypto = {
         algorithm.public.id,
       );
       // removing leading "04" which is type information
+      // (background: In crypto.subtle, P-256 curve points are represented as 65 bytes:
+      // the type (0x04 == non-compressed representation), and a pair of (x,y) coordinates (each 32 bytes).
+      // In the native API (cryptokit), the type is implicitly non-compressed; instead it only expect the (x,y) coordinates.
+      // See also: https://tools.ietf.org/id/draft-jivsov-ecc-compact-05.html#rfc.section.3 )
       if (publicKeyHexString.length === 130) {
         publicKeyHexString = publicKeyHexString.slice(2);
       }

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -1,0 +1,36 @@
+/* eslint-disable import/prefer-default-export */
+import { NativeModules } from 'react-native';
+
+function toHexString(buffer: ArrayBuffer) {
+  return Array.prototype.map
+    .call(new Uint8Array(buffer), x => `00${x.toString(16)}`.slice(-2))
+    .join('');
+}
+
+function toByteArray(hexString: string): ArrayBuffer {
+  const typedArray = new Uint8Array(
+    (hexString.match(/[\da-f]{2}/gi) || []).map((h: string) => {
+      return parseInt(h, 16);
+    }),
+  );
+  return typedArray.buffer;
+}
+
+export const crypto = {
+  subtle: {
+    async digest(
+      algorithm: string | { name: string },
+      data: ArrayBuffer,
+    ): Promise<ArrayBuffer> {
+      const algorithmName =
+        typeof algorithm === 'string' ? algorithm : algorithm.name;
+      const serializedData = toHexString(data);
+
+      const hexHash = await NativeModules.WindowCrypto.digest(
+        algorithmName,
+        serializedData,
+      );
+      return toByteArray(hexHash);
+    },
+  },
+};

--- a/ReactNative/js/globals/window/crypto.ts
+++ b/ReactNative/js/globals/window/crypto.ts
@@ -147,6 +147,8 @@ export const crypto = {
     async exportKey(format: string, key: CryptoKey): Promise<ArrayBuffer> {
       let rawKey = await NativeModules.WindowCrypto.exportKey(key.id);
       if (key.type === 'public') {
+        // crypto.subtle expects the type of the representation (0x04 == non-compressed) in the first byte
+        // (for details, refer to the remarks in deriveKey)
         rawKey = `04${rawKey}`;
       }
       return hexStringToByteArray(rawKey);

--- a/ReactNative/js/setup-globals.js
+++ b/ReactNative/js/setup-globals.js
@@ -7,7 +7,7 @@ import { DOMParser } from './globals/window/DOMParser';
 import { crypto } from './globals/window/crypto';
 
 window.DOMParser = DOMParser;
-if (Platform.OS === 'ios' && Platform.Version >= 13) {
+if (NativeModules.WindowCrypto.isAvailable) {
   // window.crypto cannot be reassigned in Chrome, so those APIs have to be tested in Safari
   try {
     window.crypto = crypto;

--- a/ReactNative/js/setup-globals.js
+++ b/ReactNative/js/setup-globals.js
@@ -1,9 +1,16 @@
-import { NativeEventEmitter, NativeModules } from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import networkStatus from './globals/browser/networkStatus';
 import tabs from './globals/browser/tabs';
 import search from './globals/browser/search';
 import './globals/navigator/userAgent';
-import './globals/window/DOMParser';
+import { DOMParser } from './globals/window/DOMParser';
+import { crypto } from './globals/window/crypto';
+
+window.DOMParser = DOMParser;
+if (Platform.OS === 'ios' && Platform.Version >= 13) {
+  // window.crypto cannot be reassigned in Chrome, so those APIs have to be tested in Safari
+  window.crypto = crypto;
+}
 
 const browser = {
   networkStatus,

--- a/ReactNative/js/setup-globals.js
+++ b/ReactNative/js/setup-globals.js
@@ -9,7 +9,11 @@ import { crypto } from './globals/window/crypto';
 window.DOMParser = DOMParser;
 if (Platform.OS === 'ios' && Platform.Version >= 13) {
   // window.crypto cannot be reassigned in Chrome, so those APIs have to be tested in Safari
-  window.crypto = crypto;
+  try {
+    window.crypto = crypto;
+  } catch (e) {
+    // breaks debugging in Chrome
+  }
 }
 
 const browser = {

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -5419,6 +5419,7 @@
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,
 				E4CD9E911A6897FB00318571 /* ReaderMode.swift in Sources */,
 				2BC457FE23F135B200057204 /* PhotonActionSheetCollectionCell.swift in Sources */,
+				46CA60E82317E0DC0010CE6B /* LocaleConstants.m in Sources */,
 				460C247D23ED73EC00D922B0 /* WindowCrypto.m in Sources */,
 				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,

--- a/UserAgent.xcodeproj/project.pbxproj
+++ b/UserAgent.xcodeproj/project.pbxproj
@@ -211,6 +211,10 @@
 		460C248223F18E6600D922B0 /* InsightsFeatureReactNativeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C248023F18E6600D922B0 /* InsightsFeatureReactNativeModule.swift */; };
 		460C248423F18E7A00D922B0 /* InsightsFeatureReactNativeModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 460C248323F18E7A00D922B0 /* InsightsFeatureReactNativeModule.m */; };
 		460C248523F18E7A00D922B0 /* InsightsFeatureReactNativeModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 460C248323F18E7A00D922B0 /* InsightsFeatureReactNativeModule.m */; };
+		460C247A23ED73D700D922B0 /* WindowCryto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C247923ED73D700D922B0 /* WindowCryto.swift */; };
+		460C247B23ED73D700D922B0 /* WindowCryto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C247923ED73D700D922B0 /* WindowCryto.swift */; };
+		460C247D23ED73EC00D922B0 /* WindowCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 460C247C23ED73EC00D922B0 /* WindowCrypto.m */; };
+		460C247E23ED73EC00D922B0 /* WindowCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 460C247C23ED73EC00D922B0 /* WindowCrypto.m */; };
 		461E5E59234F6891004DDE84 /* brand.strings in Resources */ = {isa = PBXBuildFile; fileRef = 461E5E58234F6891004DDE84 /* brand.strings */; };
 		461E5E5B234F68A7004DDE84 /* brand.strings in Resources */ = {isa = PBXBuildFile; fileRef = 461E5E5A234F68A7004DDE84 /* brand.strings */; };
 		4620EA492350ABF9004586CF /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4620EA482350ABF9004586CF /* Search.swift */; };
@@ -1343,6 +1347,8 @@
 		460C247523EB0D3200D922B0 /* safari-popups-network.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "safari-popups-network.json"; sourceTree = "<group>"; };
 		460C248023F18E6600D922B0 /* InsightsFeatureReactNativeModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsFeatureReactNativeModule.swift; sourceTree = "<group>"; };
 		460C248323F18E7A00D922B0 /* InsightsFeatureReactNativeModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InsightsFeatureReactNativeModule.m; sourceTree = "<group>"; };
+		460C247923ED73D700D922B0 /* WindowCryto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCryto.swift; sourceTree = "<group>"; };
+		460C247C23ED73EC00D922B0 /* WindowCrypto.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WindowCrypto.m; sourceTree = "<group>"; };
 		461E5E58234F6891004DDE84 /* brand.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = brand.strings; sourceTree = "<group>"; };
 		461E5E5A234F68A7004DDE84 /* brand.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = brand.strings; sourceTree = "<group>"; };
 		4620EA482350ABF9004586CF /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
@@ -2550,6 +2556,15 @@
 			path = Insights;
 			sourceTree = "<group>";
 		};
+		460C247823ED73B300D922B0 /* WindowAPI */ = {
+			isa = PBXGroup;
+			children = (
+				460C247923ED73D700D922B0 /* WindowCryto.swift */,
+				460C247C23ED73EC00D922B0 /* WindowCrypto.m */,
+			);
+			path = WindowAPI;
+			sourceTree = "<group>";
+		};
 		463432F6233251F70014A9F0 /* UserAgent */ = {
 			isa = PBXGroup;
 			children = (
@@ -2604,6 +2619,7 @@
 				46442CE9238BE148002E6D85 /* BrowserCore.swift */,
 				463432FA233381C70014A9F0 /* BrowserCoreClient.swift */,
 				46CA610123180E1A0010CE6B /* Icons.xcassets */,
+				460C247823ED73B300D922B0 /* WindowAPI */,
 				46FA068523BB741E00B22F71 /* BrowserAPI */,
 				46CA60D42316B9D00010CE6B /* NativeModules */,
 				46CA610D23190ABD0010CE6B /* NativeUIComponents */,
@@ -5105,6 +5121,7 @@
 				2BFB7C37238FA9A400CE2E69 /* AutomaticForgetModePolicy.swift in Sources */,
 				046C031523ABFE9F00D826E3 /* PrivacyDashboardUtils.swift in Sources */,
 				463432F92332521F0014A9F0 /* Telemetry.swift in Sources */,
+				460C247E23ED73EC00D922B0 /* WindowCrypto.m in Sources */,
 				C53212E423A3EB2900AEC9B2 /* PrivacyStatementData.swift in Sources */,
 				46569CC723CA5BA800224DC2 /* PrivacyStatsView.swift in Sources */,
 				ACB7374823042BAB00FA5626 /* TestAppDelegate.swift in Sources */,
@@ -5304,6 +5321,7 @@
 				ACB737F323042BAB00FA5626 /* TwoLineCell.swift in Sources */,
 				ACB737F423042BAB00FA5626 /* SettingsLoadingView.swift in Sources */,
 				ACB737F523042BAB00FA5626 /* InstructionsViewController.swift in Sources */,
+				460C247B23ED73D700D922B0 /* WindowCryto.swift in Sources */,
 				ACB737F623042BAB00FA5626 /* IntroViewController.swift in Sources */,
 				46E9660A236B33A1003C23F3 /* Constants.swift in Sources */,
 			);
@@ -5401,7 +5419,7 @@
 				DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */,
 				E4CD9E911A6897FB00318571 /* ReaderMode.swift in Sources */,
 				2BC457FE23F135B200057204 /* PhotonActionSheetCollectionCell.swift in Sources */,
-				46CA60E82317E0DC0010CE6B /* LocaleConstants.m in Sources */,
+				460C247D23ED73EC00D922B0 /* WindowCrypto.m in Sources */,
 				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
 				CEFA977E1FAA6B490016F365 /* SyncContentSettingsViewController.swift in Sources */,
@@ -5450,6 +5468,7 @@
 				E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */,
 				39CE74F821A83105007AE4F2 /* TranslationSettingsController.swift in Sources */,
 				460C248123F18E6600D922B0 /* InsightsFeatureReactNativeModule.swift in Sources */,
+				460C247A23ED73D700D922B0 /* WindowCryto.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				D0625CA8208FC47A0081F3B2 /* BrowserViewController+DownloadQueueDelegate.swift in Sources */,
 				2B8DDBB523A389B800D2CE7A /* PrivacyStatementMessageCell.swift in Sources */,

--- a/UserAgent/HumanWebFeature.swift
+++ b/UserAgent/HumanWebFeature.swift
@@ -12,7 +12,6 @@ import Shared
 class HumanWebFeature: NSObject {
     private weak var tabManager: TabManager!
     private let queue = DispatchQueue(label: "human-web")
-    private let delayedInteraval = DispatchTimeInterval.seconds(15)
     private var processPendingJobsWorkItem: DispatchWorkItem?
 
     init(tabManager: TabManager) {
@@ -31,7 +30,7 @@ class HumanWebFeature: NSObject {
         self.processPendingJobsWorkItem = workItem
 
         self.queue.asyncAfter(
-            deadline: .now() + delayedInteraval,
+            deadline: .now() + DispatchTimeInterval.seconds(Int.random(in: 10..<20)),
             execute: workItem)
     }
 }

--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ moment.locale(NativeModules.LocaleConstants.lang);
 prefs.set('tabSearchEnabled', true);
 prefs.set('modules.autoconsent.enabled', false);
 
+const isDebug = NativeModules.Constants.isDebug || NativeModules.Constants.isCI;
+
 const app = new App({
   browser: global.browser,
-  debug: NativeModules.Constants.isDebug || NativeModules.Constants.isCI,
+  debug: isDebug,
   config: {
     ...config,
     settings: {
@@ -46,6 +48,7 @@ const app = new App({
           platform: 'ios',
         },
       },
+      HW_CHANNEL: isDebug ? 'ios-debug' : 'ios',
     },
   },
 });

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ YellowBox.ignoreWarnings([
 moment.locale(NativeModules.LocaleConstants.lang);
 
 prefs.set('tabSearchEnabled', true);
+prefs.set('modules.autoconsent.enabled', false);
 
 const app = new App({
   browser: global.browser,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import React from 'react';
-import { AppRegistry, YellowBox, NativeModules } from 'react-native';
+import { AppRegistry, YellowBox, NativeModules, Platform } from 'react-native';
 import './ReactNative/js/setup-globals';
 import App from 'browser-core-user-agent-ios/build/modules/core/app';
 import config from 'browser-core-user-agent-ios/build/modules/core/config';
@@ -20,6 +20,7 @@ import BridgeManager from './ReactNative/js/bridge-manager';
 import Logo from './ReactNative/js/components/Logo';
 import { ThemeWrapperComponentProvider } from './ReactNative/js/contexts/theme';
 import moment from './ReactNative/js/services/moment';
+import { seedRandom } from './ReactNative/js/globals/window/crypto';
 
 YellowBox.ignoreWarnings([
   'Warning: componentWillMount',
@@ -47,7 +48,19 @@ const app = new App({
     },
   },
 });
-const appReady = app.start();
+const appReady = new Promise(resolve => {
+  (async () => {
+    try {
+      if (Platform.OS === 'ios' && Platform.Version >= 13) {
+        await seedRandom();
+      }
+    } catch (e) {
+      // no random, no problem
+    }
+    await app.start();
+    resolve();
+  })();
+});
 
 app.modules['insights'].background.actions['reportStats'] = async function (tabId, stats) {
   await this.db.insertPageStats(tabId, stats);

--- a/index.js
+++ b/index.js
@@ -49,10 +49,11 @@ const app = new App({
     },
   },
 });
+
 const appReady = new Promise(resolve => {
   (async () => {
     try {
-      if (Platform.OS === 'ios' && Platform.Version >= 13) {
+      if (NativeModules.WindowCrypto.isAvailable) {
         await seedRandom();
       }
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6317,6 +6317,10 @@
             "is-stream": "^1.0.1"
           }
         },
+        "node-forge": {
+          "version": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2",
+          "from": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2"
+        },
         "react": {
           "version": "16.6.3",
           "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
@@ -12169,10 +12173,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-    },
-    "node-forge": {
-      "version": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2",
-      "from": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2"
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6262,8 +6262,8 @@
       "dev": true
     },
     "browser-core-user-agent-ios": {
-      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.579c450.tgz",
-      "integrity": "sha512-sZkqoY3DRgRs4N1CGi9azrCQC6tovb8zU/mlUS8NSpj0bIDU4n9w6MC9jgLPMARpdtvOBMELAjEHimfpTFkNXg==",
+      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.029861d.tgz",
+      "integrity": "sha512-UN8tL9P8VIcLOh9MyzTL4dOAL7V3SsHhBml4MoCb83/R7eg7ZPPBv4mBV+g/x9Bs2uVaIxCToHXnjq7uvRCpGQ==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
         "@cliqz/adblocker-webextension": "^1.8.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6262,12 +6262,12 @@
       "dev": true
     },
     "browser-core-user-agent-ios": {
-      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/v3.43/3.43.0.f83c2b4.tgz",
-      "integrity": "sha512-OZpuH7FB+m8dA+n/4b5YwJl67GOlnKsFi+QJIcZDNgenQyKIXeSo39I8bvufcQxEUjvvPA0DDQCf34BqbOOdug==",
+      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.579c450.tgz",
+      "integrity": "sha512-sZkqoY3DRgRs4N1CGi9azrCQC6tovb8zU/mlUS8NSpj0bIDU4n9w6MC9jgLPMARpdtvOBMELAjEHimfpTFkNXg==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
-        "@cliqz/adblocker-webextension": "^1.3.0",
-        "@cliqz/adblocker-webextension-cosmetics": "^1.3.0",
+        "@cliqz/adblocker-webextension": "^1.8.6",
+        "@cliqz/adblocker-webextension-cosmetics": "^1.8.6",
         "@cliqz/autoconsent": "^0.4.0",
         "@cliqz/url-parser": "^1.1.1",
         "abortcontroller-polyfill": "^1.3.0",
@@ -6293,7 +6293,6 @@
         "react-native-web": "0.9.9",
         "react-toggle-display": "^2.2.0",
         "react-tooltip": "3.9.0",
-        "react-touch-carousel": "0.8.3",
         "rusha": "^0.8.13",
         "rxjs": "^6.4.0",
         "sanitize-filename": "^1.6.1",
@@ -6303,6 +6302,7 @@
         "tldts-experimental": "^5.6.1",
         "tooltipster": "^4.2.6",
         "ua-parser-js": "^0.7.21",
+        "uuid": "^7.0.0",
         "webextension-polyfill": "^0.4.0",
         "whatwg-fetch": "^3.0.0",
         "ytdl-core": "^1.0.6"
@@ -6316,10 +6316,6 @@
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
           }
-        },
-        "node-forge": {
-          "version": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2",
-          "from": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2"
         },
         "react": {
           "version": "16.6.3",
@@ -6336,6 +6332,11 @@
           "version": "0.7.21",
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
           "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+        },
+        "uuid": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.1.tgz",
+          "integrity": "sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA=="
         }
       }
     },
@@ -12174,6 +12175,10 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "node-forge": {
+      "version": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2",
+      "from": "git+https://git@github.com/digitalbazaar/forge.git#af3f590af9d3c809e1cb44b2bb5398a3a6b944c2"
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12916,11 +12921,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -13208,21 +13208,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      },
-      "dependencies": {
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13331,16 +13316,6 @@
         "prop-types": "^15.5.10",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^3.0.0"
-      }
-    },
-    "react-motion": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-      "requires": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
       }
     },
     "react-native": {
@@ -13652,14 +13627,6 @@
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0",
         "sanitize-html-react": "^1.13.0"
-      }
-    },
-    "react-touch-carousel": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-touch-carousel/-/react-touch-carousel-0.8.3.tgz",
-      "integrity": "sha512-UYU46RjfZfMiTtKaa/M0nZWzmxNF2JjtOtfziA1I+QEV22yEs6pvnnnmuzs9cMSeFcvONqA5gwiGJ9hORg5Gww==",
-      "requires": {
-        "react-motion": "0.5.2"
       }
     },
     "read-pkg": {
@@ -15098,16 +15065,16 @@
       "integrity": "sha512-RsQLuUuzNCaf57BaOSp08XNQ+ufEfAd4H0ZQQnV4+RGhGo3i1Ym8P6mFDwD47OQrgxwdnRKGH0E3hpN2WVyr5A=="
     },
     "tldts-core": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.6.8.tgz",
-      "integrity": "sha512-fEAkTMPviMVie2+KIxIZ9A3WzraFC4z7E+jtMRwTmvAWJDcAH2pwPAp2ai4VvLJM3NuUcoPCJBQggvUbxxbBHw=="
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.6.9.tgz",
+      "integrity": "sha512-MOvSUUxUyNmNK7R7cJKBvWys1rufuobWpPaVcGJd8EEsIyJzSVOlA5Y9l9V1Z0FdzlPMBAYPcpKuoQkvH7pfRg=="
     },
     "tldts-experimental": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-5.6.8.tgz",
-      "integrity": "sha512-LEgNhT6YDEhQ/PMbBE6pVKwG9AHkiAuZ/9IrCSnpMOOV254GFInAye+TDoU9KeVcAfZ09yzKQpRFGt2hQ97+qg==",
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-5.6.9.tgz",
+      "integrity": "sha512-uH6koG/FNlF6zMZoFseGoBSQO4FRaitVQaPigkRy3IYRsiwM2Sj9k6cs9osKURWlsq9tauWe+6hdNEPHQ0Rwqw==",
       "requires": {
-        "tldts-core": "^5.6.8"
+        "tldts-core": "^5.6.9"
       }
     },
     "tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6420,17 +6420,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -12221,6 +12210,17 @@
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@cliqz/component-ui-snippet-weather": "^0.5.2",
     "@cliqz/indexeddbshim": "^4.1.2",
     "@react-native-community/netinfo": "^4.6.1",
-    "browser-core-user-agent-ios": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.579c450.tgz",
+    "browser-core-user-agent-ios": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.029861d.tgz",
     "cliqz-logo-database": "^0.5.5",
     "glob-to-regexp": "^0.4.1",
     "jsdom-jscore-rn": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@cliqz/component-ui-snippet-weather": "^0.5.2",
     "@cliqz/indexeddbshim": "^4.1.2",
     "@react-native-community/netinfo": "^4.6.1",
-    "browser-core-user-agent-ios": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/v3.43/3.43.0.f83c2b4.tgz",
+    "browser-core-user-agent-ios": "https://s3.amazonaws.com/cdncliqz/update/edge/user-agent-ios/master/3.45.0.579c450.tgz",
     "cliqz-logo-database": "^0.5.5",
     "glob-to-regexp": "^0.4.1",
     "jsdom-jscore-rn": "^0.1.7",


### PR DESCRIPTION
Required for #614 

This PR aims to implement a subset of `window.crypto` APIs:
- [x] `crypto.getRandomValues`
- [x] `crypto.subtle.digest`
- [x] `crypto.subtle.generateKey`
- [x] `crypto.subtle.exportKey`
- [x] `crypto.subtle.importKey`
- [x] `crypto.subtle.deriveKey`
- [x] `crypto.subtle.encrypt`
- [x] `crypto.subtle.decrypt`

Example code that should be able to run:
https://cdn.cliqz.com/browser-f/fun-demo/ecies-example/example.js