### PR TITLE
Open Link UseCase should not switch to tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1074,6 +1074,7 @@ class BrowserViewController: UIViewController {
     }
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool = false, isPrivileged: Bool) {
+        popToBVC()
         if let selectedTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(selectedTab)
         }

--- a/UserAgent/Interceptor/InterceptorFeature.swift
+++ b/UserAgent/Interceptor/InterceptorFeature.swift
@@ -47,7 +47,7 @@ extension InterceptorFeature: InterceptorDelegate {
             ui.showAntiPhishingAlert(tab: tab, url: url, policy: policy)
         case .automaticForgetMode:
             policy.allowListUrl(url)
-            self.useCases.openLink.openNewPrivateTab(url: url)
+            self.useCases.openLink.openNewForgetModeTab(url: url)
         default:
             break
         }

--- a/UserAgent/UseCases/ContextMenuUseCase.swift
+++ b/UserAgent/UseCases/ContextMenuUseCase.swift
@@ -127,7 +127,7 @@ class ContextMenuUseCase {
 
     private func createActionOpenInNewPrivateTab(site: Site, actionCompletion: @escaping ContextMenuActionCompletion) -> PhotonActionSheetItem {
         let actionSheetItem = PhotonActionSheetItem(title: Strings.HomePanel.ContextMenu.OpenInNewPrivateTab, iconString: "forgetMode") { action in
-            self.openLink.openNewPrivateTab(url: site.tileURL)
+            self.openLink.openNewForgetModeTab(url: site.tileURL)
             actionCompletion()
         }
         return actionSheetItem

--- a/UserAgent/UseCases/OpenLinkUseCases.swift
+++ b/UserAgent/UseCases/OpenLinkUseCases.swift
@@ -69,14 +69,14 @@ class OpenLinkUseCases {
 
     func openNewTab(url: URL? = nil) {
         guard let url = url else { return }
-        self.browserViewController.switchToTabForURLOrOpen(url, isPrivate: false, isPrivileged: true)
+        self.browserViewController.openURLInNewTab(url, isPrivate: false, isPrivileged: true)
     }
 
-    // MARK: - New Private Tab Methods
+    // MARK: - New Forget Mode Tab Methods
 
-    func openNewPrivateTab(url: URL? = nil) {
+    func openNewForgetModeTab(url: URL? = nil) {
         guard let url = url else { return }
-        self.browserViewController.switchToTabForURLOrOpen(url, isPrivate: true, isPrivileged: true)
+        self.browserViewController.openURLInNewTab(url, isPrivate: true, isPrivileged: true)
     }
 
 }


### PR DESCRIPTION
Switch to tab functionality breaks Interceptor are intersepted url is already set (but blocked) on the webview.