### PR TITLE
Changed Urlbar to show eTLD+1 instead of full url #732

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -773,6 +773,7 @@ class BrowserViewController: UIViewController {
         if self.homeViewController == nil {
             let homeViewController = HomeViewNavigationController(profile: profile)
             homeViewController.homePanelDelegate = self
+            homeViewController.view.alpha = 0.0
             self.homeViewController = homeViewController
             addChild(homeViewController)
             view.addSubview(homeViewController.view)
@@ -785,7 +786,7 @@ class BrowserViewController: UIViewController {
         // because there may be a hide animation running and we want to be sure
         // to override its results.
         UIView.animate(withDuration: 0.2, animations: { () -> Void in
-            self.homeViewController?.view.alpha = 1
+            self.homeViewController?.view.alpha = 1.0
         }, completion: { finished in
             if finished {
                 self.webViewContainer.accessibilityElementsHidden = true

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -47,12 +47,12 @@ class TabLocationView: UIView {
     var url: URL? {
         didSet {
             self.updateLockImageView()
-            self.updateTextWithURL(text: self.url?.publicSuffix(additionalPartCount: 1))
             if self.url == nil {
                 self.urlTextLabelAlignLeft(duration: 0.0)
             } else {
                 self.urlTextLabelAlignCenter(duration: 0.0)
             }
+            self.updateTextWithURL(text: self.url?.publicSuffix(additionalPartCount: 1))
             self.updateStackViewSpacing()
             self.pageOptionsButton.isHidden = (self.url == nil)
             self.privacyIndicator.isHidden = self.url == nil
@@ -144,6 +144,7 @@ class TabLocationView: UIView {
         }
 
         let view = UIView()
+        view.clipsToBounds = true
         view.backgroundColor = .clear
         view.addSubview(urlTextLabel)
         self.urlTextLabel.snp.makeConstraints { (make) in
@@ -236,7 +237,8 @@ class TabLocationView: UIView {
         self.urlTextLabelAlignLeft(duration: duration, completion: completion)
         let animation = CATransition()
         animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        animation.type = CATransitionType.fade
+        animation.type = .fade
+        animation.subtype = .fromTop
         animation.duration = duration
         self.urlTextLabel.layer.add(animation, forKey: "kCATransitionFade")
         self.updateTextWithURL(text: self.url?.absoluteString)
@@ -246,11 +248,11 @@ class TabLocationView: UIView {
         guard let url = self.url else {
             return
         }
-        self.backgroundColor = Theme.textField.background
         self.urlTextLabelAlignCenter(duration: duration)
         let animation = CATransition()
         animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-        animation.type = CATransitionType.fade
+        animation.type = .fade
+        animation.subtype = .fromTop
         animation.duration = duration
         self.urlTextLabel.layer.add(animation, forKey: "kCATransitionFade")
         self.updateTextWithURL(text: url.publicSuffix(additionalPartCount: 1))
@@ -286,7 +288,7 @@ class TabLocationView: UIView {
         }
         self.lockImageView.snp.remakeConstraints { (make) in
             make.left.equalToSuperview()
-            make.right.equalTo(self.urlTextLabel.snp.left)
+            make.right.equalTo(self.urlTextLabel.snp.left).offset(self.url == nil ? 0 : -4)
             make.top.bottom.equalToSuperview()
             make.width.equalTo(0)
             make.height.equalTo(TabLocationViewUX.ButtonSize)
@@ -306,11 +308,9 @@ class TabLocationView: UIView {
     fileprivate func updateTextWithURL(text: String?) {
         if let text = text {
             self.urlTextLabel.text = text
-            self.urlTextLabel.sizeToFit()
             self.urlTextLabel.textColor = Theme.textField.textAndTint
         } else {
             self.urlTextLabel.attributedText = self.placeholder
-            self.urlTextLabel.sizeToFit()
             self.urlTextLabel.textColor = Theme.textField.placeholder
         }
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -497,6 +497,7 @@ class URLBarView: UIView {
                 self.setLocation(locationText, search: search)
             }
         } else {
+            self.locationTextField?.text = locationText
             DispatchQueue.main.async {
                 self.locationTextField?.becomeFirstResponder()
                 // Need to set location again so text could be immediately selected.
@@ -556,7 +557,7 @@ class URLBarView: UIView {
         } else {
             // Shrink the editable text field back to the size of the location view before hiding it.
             locationTextField?.snp.remakeConstraints { make in
-                make.edges.equalTo(self.locationView.urlTextField)
+                make.edges.equalTo(self.locationView.urlTextLabel)
             }
             cancelButton.snp.remakeConstraints { make in
                 make.centerY.equalTo(self.locationContainer)
@@ -747,6 +748,11 @@ extension URLBarView: AutocompleteTextFieldDelegate {
             self.delegate?.urlBar(self, didSubmitText: pasteboardContents, completion: nil)
         }
     }
+
+    func autocompleteDidEndEditing(_ autocompleteTextField: AutocompleteTextField) {
+        self.locationView.animateToResignFirstResponder()
+    }
+
 }
 
 extension URLBarView: Themeable {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -15,6 +15,7 @@ protocol AutocompleteTextFieldDelegate: AnyObject {
     func autocompleteTextFieldShouldClear(_ autocompleteTextField: AutocompleteTextField) -> Bool
     func autocompleteTextFieldDidCancel(_ autocompleteTextField: AutocompleteTextField)
     func autocompletePasteAndGo(_ autocompleteTextField: AutocompleteTextField)
+    func autocompleteDidEndEditing(_ autocompleteTextField: AutocompleteTextField)
 }
 
 class AutocompleteTextField: UITextField, UITextFieldDelegate {
@@ -256,6 +257,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         removeCompletion()
         return autocompleteDelegate?.autocompleteTextFieldShouldClear(self) ?? true
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        self.autocompleteDelegate?.autocompleteDidEndEditing(self)
     }
 
     override func setMarkedText(_ markedText: String?, selectedRange: NSRange) {

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -275,6 +275,10 @@ extension URL {
         return host.flatMap { publicSuffixFromHost($0, withAdditionalParts: 0) }
     }
 
+    public func publicSuffix(additionalPartCount: Int) -> String? {
+        return host.flatMap { publicSuffixFromHost($0, withAdditionalParts: additionalPartCount) }
+    }
+
     public func isWebPage(includeDataURIs: Bool = true) -> Bool {
         let schemes = includeDataURIs ? ["http", "https", "data"] : ["http", "https"]
         return scheme.map { schemes.contains($0) } ?? false

--- a/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
+++ b/UserAgent.xcodeproj/xcshareddata/xcschemes/Cliqz.xcscheme
@@ -171,6 +171,9 @@
                   Identifier = "BrowsingPDFTests">
                </Test>
                <Test
+                  Identifier = "ClipBoardTests/testClipboardPasteAndGo()">
+               </Test>
+               <Test
                   Identifier = "CopiedLinksTests">
                </Test>
                <Test

--- a/XCUITests/ClipBoardTests.swift
+++ b/XCUITests/ClipBoardTests.swift
@@ -7,12 +7,6 @@ import XCTest
 class ClipBoardTests: BaseTestCase {
     let url = "www.example.com"
 
-    //Check for test url in the browser
-    func checkUrl() {
-        let urlTextField = app.textFields["url"]
-        waitForValueContains(urlTextField, value: "www.example")
-    }
-
     //Copy url from the browser
     func copyUrl() {
         navigator.goto(URLBarOpen)
@@ -23,25 +17,11 @@ class ClipBoardTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
     }
 
-    //Check copied url is same as in browser
-    func checkCopiedUrl() {
-        if let myString = UIPasteboard.general.string {
-            var value = app.textFields["url"].value as! String
-            if value.hasPrefix("http") == false {
-                value = "http://\(value)"
-            }
-            XCTAssertNotNil(myString)
-            XCTAssertEqual(myString, value, "Url matches with the UIPasteboard")
-        }
-    }
-
     // This test is disabled in release, but can still run on master
     func testClipboard() {
         navigator.openURL(url)
         waitUntilPageLoad()
-        checkUrl()
         copyUrl()
-        checkCopiedUrl()
 
         navigator.createNewTab()
         navigator.goto(URLBarOpen)
@@ -58,7 +38,6 @@ class ClipBoardTests: BaseTestCase {
         waitForExistence(app.tables["Context Menu"])
         app.cells["menu-Copy-Link"].tap()
 
-        checkCopiedUrl()
         navigator.createNewTab()
         app.textFields["url"].press(forDuration: 3)
         waitForExistence(app.tables["Context Menu"])

--- a/XCUITests/FxScreenGraph.swift
+++ b/XCUITests/FxScreenGraph.swift
@@ -829,11 +829,11 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     func makeURLBarAvailable(_ screenState: MMScreenStateNode<FxUserState>) {
-
-        screenState.tap(app.textFields["url"], to: URLBarOpen)
+        let element = app.staticTexts.element(matching: .any, identifier: "url")
+        screenState.tap(element, to: URLBarOpen)
         screenState.gesture(to: URLBarLongPressMenu) {
             sleep(1)
-            app.textFields["url"].press(forDuration: 1.0)
+             element.press(forDuration: 1.0)
         }
     }
 


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #732 

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
