### PR TITLE
UrlBar don't show filenames of downloaded files #941

### DIFF
--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -277,7 +277,7 @@ class TabLocationView: UIView {
         if let searchUrl = SearchURL(url) {
             return searchUrl.query
         }
-        if url.isHostIPAddress || url.isIPv6 {
+        if url.isHostIPAddress || url.isIPv6 || url.isFileURL {
             return url.host ?? ""
         }
         return url.publicSuffix(additionalPartCount: 1) ?? ""


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #941 

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
