### PR TITLE
Fix: Cliqz and Ghostery colors got mixed

### DIFF
--- a/Branding/Cliqz/Configuration/Assets/colors.xcassets/LaunchScreenBackground.colorset/Contents.json
+++ b/Branding/Cliqz/Configuration/Assets/colors.xcassets/LaunchScreenBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.941",
-          "green" : "0.682",
-          "red" : "0.000"
+          "blue" : "0.976",
+          "green" : "0.961",
+          "red" : "0.949"
         }
       },
       "idiom" : "universal"

--- a/Branding/Ghostery/Configuration/Assets/colors.xcassets/LaunchScreenBackground.colorset/Contents.json
+++ b/Branding/Ghostery/Configuration/Assets/colors.xcassets/LaunchScreenBackground.colorset/Contents.json
@@ -1,20 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.949",
           "alpha" : "1.000",
-          "blue" : "0.976",
-          "green" : "0.961"
+          "blue" : "0.941",
+          "green" : "0.682",
+          "red" : "0.000"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #

## Implementation details
<!--- Provide a general summary of your changes in the Title above. Attach screenshot if relevant.-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
