### PR TITLE
Fixed empty "Search" section settings screen issue.

### DIFF
--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -31,27 +31,25 @@ class AppSettingsTableViewController: SettingsTableViewController {
     }
 
     override func generateSettings() -> [SettingSection] {
-        var settings = [
+        var settings = [SettingSection]()
+        if Features.Search.QuickSearch.isEnabled || Features.Search.AdditionalSearchEngines.isEnabled {
+            settings.append(self.searchSettingSection())
+        }
+        settings.append(contentsOf: [
             self.privacySettingSection(),
             self.privacyDashboardSettingSection(),
-            self.generalSettingSection(),
+        ])
+        if Features.TodayWidget.isEnabled {
+            settings.append(self.todayWidgetSettingSection())
+        }
+        settings.append(self.generalSettingSection())
+        if Features.News.isEnabled {
+            settings.append(self.newsSettingSection())
+        }
+        settings.append(contentsOf: [
             self.supportSettingSection(),
             self.aboutSettingSection(),
-        ]
-        var todayWidgetIndex = 2
-        var newsIndex = 3
-        if Features.Search.QuickSearch.isEnabled || Features.Search.AdditionalSearchEngines.isEnabled {
-            settings.insert(self.searchSettingSection(), at: 0)
-            todayWidgetIndex += 1
-            newsIndex += 1
-        }
-        if Features.TodayWidget.isEnabled {
-            settings.insert(self.todayWidgetSettingSection(), at: todayWidgetIndex)
-            newsIndex += 1
-        }
-        if Features.News.isEnabled {
-            settings.insert(self.newsSettingSection(), at: newsIndex)
-        }
+        ])
         return settings
     }
 
@@ -196,21 +194,19 @@ class AppSettingsTableViewController: SettingsTableViewController {
 
     private func supportSettingSection() -> SettingSection {
         let prefs = self.profile.prefs
-        var supportSettigns = [
-            SendFeedbackSetting(),
-            PrivacyPolicySetting(),
-        ]
+        var supportSettigns = [Setting]()
         if Onboarding.isEnabled {
             supportSettigns.insert(ShowIntroductionSetting(settings: self), at: 0)
         }
+        supportSettigns.append(SendFeedbackSetting())
         if Features.HumanWeb.isEnabled {
-            supportSettigns.insert(HumanWebSetting(prefs: prefs), at: 1 + (Onboarding.isEnabled ? 1 : 0))
+            supportSettigns.append(HumanWebSetting(prefs: prefs))
         }
         if Features.Telemetry.isEnabled {
             let telemetrySetting = TelemetrySetting(prefs: prefs, attributedStatusText: NSAttributedString(string: Strings.Settings.Support.SendUsageStatus, attributes: [NSAttributedString.Key.foregroundColor: Theme.tableView.headerTextLight]))
-            let index = 1 + (Onboarding.isEnabled ? 1 : 0) + (Features.HumanWeb.isEnabled ? 1 : 0)
-            supportSettigns.insert(telemetrySetting, at: index)
+            supportSettigns.append(telemetrySetting)
         }
+        supportSettigns.append(PrivacyPolicySetting())
         return SettingSection(title: NSAttributedString(string: Strings.Settings.Support.SectionTitle), children: supportSettigns)
     }
 

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -32,18 +32,25 @@ class AppSettingsTableViewController: SettingsTableViewController {
 
     override func generateSettings() -> [SettingSection] {
         var settings = [
-            self.searchSettingSection(),
             self.privacySettingSection(),
             self.privacyDashboardSettingSection(),
             self.generalSettingSection(),
             self.supportSettingSection(),
             self.aboutSettingSection(),
         ]
+        var todayWidgetIndex = 2
+        var newsIndex = 3
+        if Features.Search.QuickSearch.isEnabled || Features.Search.AdditionalSearchEngines.isEnabled {
+            settings.insert(self.searchSettingSection(), at: 0)
+            todayWidgetIndex += 1
+            newsIndex += 1
+        }
         if Features.TodayWidget.isEnabled {
-            settings.insert(self.todayWidgetSettingSection(), at: 3)
+            settings.insert(self.todayWidgetSettingSection(), at: todayWidgetIndex)
+            newsIndex += 1
         }
         if Features.News.isEnabled {
-            settings.insert(self.newsSettingSection(), at: 5)
+            settings.insert(self.newsSettingSection(), at: newsIndex)
         }
         return settings
     }


### PR DESCRIPTION
<!--- Add a reference to the Github issue this PR relates to, if any, eg: 'Fixes #100' -->
Fix #

## Implementation details
Settings screen shows empty search section if quick search and additional search engins features are disabled.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My squashed commit messages follows the [7 golden rules](https://chris.beams.io/posts/git-commit/)
- [ ] I updated or created necessary unit tests
- [ ] I've tested my changes in Dark Mode, iPad, iOS <= 12, Landscape and in German
